### PR TITLE
docs: fix ReadTheDocs build

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of REANA.
 # Copyright (C) 2017 CERN.
 #
@@ -18,15 +20,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-include Dockerfile
-include COPYING
-include *.rst
-include *.sh
-include *.py
-include pytest.ini
-recursive-include reana_job_controller *.json
-recursive-include docs *.py
-recursive-include docs *.png
-recursive-include docs *.rst
-recursive-include docs *.txt
-recursive-include tests *.py
+"""Flask application configuration."""
+
+import pykube
+
+# FIXME do not share HTTPClient but only config
+PYKUBE_API = pykube.HTTPClient(pykube.KubeConfig.from_service_account())
+PYKUBE_API.session.verify = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,12 @@
 from __future__ import print_function
 
 import os
-import sphinx.environment
+import sys
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -196,6 +201,3 @@ texinfo_documents = [
      author, 'reana', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-# Mock autodoc imports:
-autodoc_mock_imports = ['k8s', ]


### PR DESCRIPTION
* Adds `config.py` so that pykube configuration is loaded only at
  run time. (closes #18)

* Renames `create_job` on `k8s.py` to avoid name clashing inside
  `app.py`.

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>