### PR TITLE
change job failure condition

### DIFF
--- a/reana_job_controller/k8s.py
+++ b/reana_job_controller/k8s.py
@@ -248,7 +248,7 @@ def watch_pods(job_db, config):
                     job_db[job_name]['restart_count'] = restarts
 
                     if restarts >= job_db[job_name]['max_restart_count'] and \
-                       exit_code == 1:
+                       exit_code != 0:
 
                         logging.info(
                             'Job {} reached max restarts...'.format(job_name)


### PR DESCRIPTION
Failed jobs do not fail inside job-controller if they exit with a code different from 1, this PR fails all jobs with exit code other than 0

(if the commit needs rewording, please suggest a proper leading tag)
  