### PR TITLE
dockerfile: revert uwsgi due to request timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@
 
 FROM python:3.6
 
+ENV TERM=xterm
 RUN apt-get update && \
     apt-get install -y vim-tiny && \
     pip install --upgrade pip
@@ -37,17 +38,5 @@ RUN if [ "${DEBUG}" = "true" ]; then pip install -r requirements-dev.txt; pip in
 RUN adduser --uid 1000 --disabled-password --gecos '' reanauser && \
     chown -R reanauser:reanauser /code
 USER reanauser
-
-ARG UWSGI_PROCESSES=2
-ENV UWSGI_PROCESSES ${UWSGI_PROCESSES:-2}
-ARG UWSGI_THREADS=2
-ENV UWSGI_THREADS ${UWSGI_THREADS:-2}
-ENV TERM=xterm
-
 EXPOSE 5000
-
-CMD uwsgi --module reana_job_controller.app:app \
-    --http-socket 0.0.0.0:5000 --master \
-    --processes ${UWSGI_PROCESSES} \
-    --threads ${UWSGI_THREADS} \
-    --stats /tmp/stats.socket
+CMD ["python", "reana_job_controller/app.py"]

--- a/reana_job_controller/app.py
+++ b/reana_job_controller/app.py
@@ -369,21 +369,22 @@ def get_openapi_spec():
     return jsonify(app.config['OPENAPI_SPEC'])
 
 
-app.config.from_object('reana_job_controller.config')
-
-with app.app_context():
-    app.config['OPENAPI_SPEC'] = build_openapi_spec()
-    app.config['KUBERNETES_CLIENT'] = create_api_client()
-
-job_event_reader_thread = threading.Thread(target=watch_jobs,
-                                            args=(JOB_DB,))
-
-job_event_reader_thread.start()
-
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(threadName)s - %(levelname)s: %(message)s'
-)
-
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(threadName)s - %(levelname)s: %(message)s'
+    )
+
+    app.config.from_object('config')
+
+    with app.app_context():
+        app.config['OPENAPI_SPEC'] = build_openapi_spec()
+        app.config['KUBERNETES_CLIENT'] = create_api_client()
+
+    job_event_reader_thread = threading.Thread(target=watch_jobs,
+                                               args=(JOB_DB,))
+
+    job_event_reader_thread.start()
+
+    app.run(debug=True, port=5000,
+            host='0.0.0.0')

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,6 @@ install_requires = [
     'kubernetes>=6.0.0',
     'marshmallow>=2.13',
     'reana-commons>=0.1.0',
-    'uwsgi-tools>=1.1.1',
-    'uWSGI>=2.0.17',
-    'uwsgitop>=0.10',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* The job-watcher thread stops working when running with uwsgi since
  all the requests timeout.