### PR TITLE
volume-templates: user directory as root path for jobs

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,12 +78,16 @@
         "shared_file_system": {
           "default": true,
           "type": "boolean"
+        },
+        "workflow_workspace": {
+          "type": "string"
         }
       },
       "required": [
         "docker_img",
         "experiment",
-        "job_name"
+        "job_name",
+        "workflow_workspace"
       ],
       "type": "object"
     }

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -13,11 +13,5 @@ import os
 MAX_JOB_RESTARTS = 3
 """Number of retries for a job before considering it as failed."""
 
-SHARED_FS_MAPPING = {
-    'MOUNT_SOURCE_PATH': os.getenv("SHARED_VOLUME_PATH_ROOT", '/var/reana'),
-    # Root path in the underlying shared file system to be mounted inside
-    # jobs.
-    'MOUNT_DEST_PATH': os.getenv("SHARED_VOLUME_PATH", '/var/reana'),
-    # Mount path for the shared file system volume inside jobs.
-}
-"""Mapping from the shared file system backend to the job file system."""
+SHARED_VOLUME_PATH_ROOT = os.getenv('SHARED_VOLUME_PATH_ROOT', '/var/reana')
+"""Root path of the shared volume ."""

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -193,17 +193,17 @@ def create_job():  # noqa
 
     # Validate and deserialize input
     job_request, errors = job_request_schema.load(json_data)
-
     if errors:
         return jsonify(errors), 400
-    job_parameters = dict(job_id=str(job_request['job_id']),
-                          docker_img=job_request['docker_img'],
-                          cmd=job_request['cmd'],
-                          cvmfs_mounts=job_request['cvmfs_mounts'],
-                          env_vars=job_request['env_vars'],
-                          namespace=job_request['experiment'],
-                          shared_file_system=job_request['shared_file_system'],
-                          job_type=job_request.get('job_type'))
+    job_parameters = dict(
+      job_id=str(job_request['job_id']),
+      workflow_workspace=str(job_request['workflow_workspace']),
+      docker_img=job_request['docker_img'],
+      cmd=job_request['cmd'],
+      cvmfs_mounts=job_request['cvmfs_mounts'],
+      env_vars=job_request['env_vars'],
+      shared_file_system=job_request['shared_file_system'],
+      job_type=job_request.get('job_type'))
     job_obj = k8s_instantiate_job(**job_parameters)
     if job_obj:
         job = copy.deepcopy(job_request)

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -32,6 +32,7 @@ class JobRequest(Schema):
 
     job_id = fields.UUID()
     job_name = fields.Str(required=True)
+    workflow_workspace = fields.Str(required=True)
     cmd = fields.Str(missing='')
     prettified_cmd = fields.Str(missing='')
     docker_img = fields.Str(required=True)


### PR DESCRIPTION
* Previously jobs were having mounted the whole REANA shared file
  system. With this fix jobs will be only able to access paths under
  the user/workflow owner directory.