### PR TITLE
fixture: base_app not lauching watch_jobs thread

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,5 +39,6 @@ def base_app(tmp_shared_volume_path):
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,
         "ORGANIZATIONS": ["default"],
     }
-    app_ = create_app(config_mapping=config_mapping)
+    app_ = create_app(config_mapping=config_mapping,
+                      watch_jobs=False)
     return app_


### PR DESCRIPTION
* watch_jobs thread should not be launched by base_app fixture,
  because it cause test failures due missing k8s api mocks.
  Closes #125

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>
Co-authored-by: Diego Rodriguez <diego.rodriguez.rodriguez@cern.ch>