### PR TITLE
installation: unpin urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ install_requires = [
     'marshmallow>2.13.0,<=2.20.1',
     'reana-commons[kubernetes]>=0.6.0.dev20190823,<0.7.0',
     'reana-db>=0.6.0.dev20190828,<0.7.0',
-    'urllib3<1.25,>=1.21.1',
     'htcondor==8.9.1',
     'retrying>=1.3.3',
 ]


### PR DESCRIPTION
* Unpins urllib3 since it is correctly set as a dependency in the
  Python Kubernetes client (addresses reanahub/reana-client#320).