### PR TITLE
Grid proxy

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,6 +78,9 @@
         "unpacked_img": {
           "type": "boolean"
         },
+        "voms_proxy": {
+          "type": "boolean"
+        },
         "workflow_uuid": {
           "type": "string"
         },

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -91,15 +91,16 @@ KRB5_CONFIGMAP_NAME = os.getenv('REANA_KRB5_CONFIGMAP_NAME',
 """Kerberos configMap name."""
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv('VOMSPROXY_CONTAINER_IMAGE',
-                                 'reanahub/reana-auth-vomsproxy')
+                                      'reanahub/reana-auth-vomsproxy')
 """Default docker image of VOMSPROXY sidecar container."""
 
 VOMSPROXY_CONTAINER_NAME = 'voms-proxy'
 """Name of VOMSPROXY sidecar container."""
 
 VOMSPROXY_CERT_CACHE_LOCATION = '/vomsproxy_cache/'
-"""Directory of voms-proxy certificate cache, shared between job & VOMSPROXY container.
-"""
+"""Directory of voms-proxy certificate cache.
+
+This directory is shared between job & VOMSPROXY container."""
 
 VOMSPROXY_CERT_CACHE_FILENAME = 'x509up_proxy'
 """Name of the voms-proxy certificate cache file."""

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -90,5 +90,19 @@ KRB5_CONFIGMAP_NAME = os.getenv('REANA_KRB5_CONFIGMAP_NAME',
                                 f'{REANA_COMPONENT_PREFIX}-krb5-conf')
 """Kerberos configMap name."""
 
+VOMSPROXY_CONTAINER_IMAGE = os.getenv('VOMSPROXY_CONTAINER_IMAGE',
+                                 'reanahub/reana-auth-vomsproxy')
+"""Default docker image of VOMSPROXY sidecar container."""
+
+VOMSPROXY_CONTAINER_NAME = 'voms-proxy'
+"""Name of VOMSPROXY sidecar container."""
+
+VOMSPROXY_CERT_CACHE_LOCATION = '/vomsproxy_cache/'
+"""Directory of voms-proxy certificate cache, shared between job & VOMSPROXY container.
+"""
+
+VOMSPROXY_CERT_CACHE_FILENAME = 'x509up_proxy'
+"""Name of the voms-proxy certificate cache file."""
+
 IMAGE_PULL_SECRETS = os.getenv('IMAGE_PULL_SECRETS', '').split(',')
 """Docker image pull secrets which allow the usage of private images."""

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -335,7 +335,6 @@ class KubernetesJobManager(JobManager):
             }
         ]
 
-        voms_proxy_pass = os.environ.get('VOMSPROXY_PASS')
         voms_proxy_file_path = os.path.join(
                                current_app.config['VOMSPROXY_CERT_CACHE_LOCATION'],
                                current_app.config['VOMSPROXY_CERT_CACHE_FILENAME']
@@ -346,12 +345,12 @@ class KubernetesJobManager(JobManager):
             'command': ['/bin/bash'],
             'args': ['-c', 'cp /etc/reana/secrets/userkey.pem /tmp/userkey.pem; \
                      chmod 400 /tmp/userkey.pem; \
-                     echo {voms_proxy_pass} | base64 -d | voms-proxy-init \
+                     echo $VOMSPROXY_PASS | base64 -d | voms-proxy-init \
                      --voms cms --key /tmp/userkey.pem \
                      --cert $(readlink -f /etc/reana/secrets/usercert.pem) \
                      --pwstdin --out {voms_proxy_file_path}; \
-                     chown {kubernetes_uid} {voms_proxy_file_path}'.format(voms_proxy_pass=voms_proxy_pass, \
-                     voms_proxy_file_path=voms_proxy_file_path, kubernetes_uid=self.kubernetes_uid)],
+                     chown {kubernetes_uid} {voms_proxy_file_path}'.format(voms_proxy_file_path=voms_proxy_file_path, \
+                     kubernetes_uid=self.kubernetes_uid)],
             'name': current_app.config['VOMSPROXY_CONTAINER_NAME'],
             'imagePullPolicy': 'IfNotPresent',
             'volumeMounts': [secrets_volume_mount] + volume_mounts,

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -346,7 +346,7 @@ class KubernetesJobManager(JobManager):
             'args': ['-c', 'cp /etc/reana/secrets/userkey.pem /tmp/userkey.pem; \
                      chmod 400 /tmp/userkey.pem; \
                      echo $VOMSPROXY_PASS | base64 -d | voms-proxy-init \
-                     --voms cms --key /tmp/userkey.pem \
+                     --voms $VO --key /tmp/userkey.pem \
                      --cert $(readlink -f /etc/reana/secrets/usercert.pem) \
                      --pwstdin --out {voms_proxy_file_path}; \
                      chown {kubernetes_uid} {voms_proxy_file_path}'.format(voms_proxy_file_path=voms_proxy_file_path, \

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -45,7 +45,7 @@ class KubernetesJobManager(JobManager):
     def __init__(self, docker_img=None, cmd=None, prettified_cmd=None,
                  env_vars=None, workflow_uuid=None, workflow_workspace=None,
                  cvmfs_mounts='false', shared_file_system=False, job_name=None,
-                 kerberos=False, kubernetes_uid=None, unpacked_img=False):
+                 kerberos=False, kubernetes_uid=None, unpacked_img=False, voms_proxy=False):
         """Instanciate kubernetes job manager.
 
         :param docker_img: Docker image.
@@ -70,6 +70,8 @@ class KubernetesJobManager(JobManager):
         :type kerberos: bool
         :param kubernetes_uid: User ID for job container.
         :type kubernetes_uid: int
+        :param voms_proxy: Decides if a voms-proxy certificate should be provided for job.
+        :type voms_proxy: bool
         """
         super(KubernetesJobManager, self).__init__(
             docker_img=docker_img,
@@ -83,6 +85,7 @@ class KubernetesJobManager(JobManager):
         self.cvmfs_mounts = cvmfs_mounts
         self.shared_file_system = shared_file_system
         self.kerberos = kerberos
+        self.voms_proxy = voms_proxy
         self.set_user_id(kubernetes_uid)
 
     @JobManager.execution_hook
@@ -137,6 +140,11 @@ class KubernetesJobManager(JobManager):
         self.job['spec']['template']['spec']['containers'][0]['volumeMounts'] \
             .append(secrets_volume_mount)
 
+        self.job['spec']['template']['spec']['containers'][0]['securityContext'] = \
+            client.V1PodSecurityContext(
+                run_as_group=WORKFLOW_RUNTIME_USER_GID,
+                run_as_user=self.kubernetes_uid)
+
         if self.env_vars:
             for var, value in self.env_vars.items():
                 self.job['spec']['template']['spec'][
@@ -167,13 +175,11 @@ class KubernetesJobManager(JobManager):
                 ))
                 self.job['spec']['template']['spec']['volumes'].append(volume)
 
-        self.job['spec']['template']['spec']['securityContext'] = \
-            client.V1PodSecurityContext(
-                run_as_group=WORKFLOW_RUNTIME_USER_GID,
-                run_as_user=self.kubernetes_uid)
-
         if self.kerberos:
             self._add_krb5_init_container(secrets_volume_mount)
+
+        if self.voms_proxy:
+            self._add_voms_proxy_init_container(secrets_volume_mount)
 
         backend_job_id = self._submit()
         return backend_job_id
@@ -315,6 +321,54 @@ class KubernetesJobManager(JobManager):
                            )})
         self.job['spec']['template']['spec']['initContainers'].append(
             krb5_container)
+
+    def _add_voms_proxy_init_container(self, secrets_volume_mount):
+        """Add  sidecar container for a job."""
+        ticket_cache_volume = {
+            'name': 'voms-proxy-cache',
+            'emptyDir': {}
+        }
+        volume_mounts = [
+            {
+                'name': ticket_cache_volume['name'],
+                'mountPath': current_app.config['VOMSPROXY_CERT_CACHE_LOCATION']
+            }
+        ]
+
+        voms_proxy_pass = os.environ.get('VOMSPROXY_PASS')
+        voms_proxy_file_path = os.path.join(
+                               current_app.config['VOMSPROXY_CERT_CACHE_LOCATION'],
+                               current_app.config['VOMSPROXY_CERT_CACHE_FILENAME']
+                           )
+
+        voms_proxy_container = {
+            'image': current_app.config['VOMSPROXY_CONTAINER_IMAGE'],
+            'command': ['/bin/bash'],
+            'args': ['-c', 'cp /etc/reana/secrets/userkey.pem /tmp/userkey.pem; \
+                     chmod 400 /tmp/userkey.pem; \
+                     echo {voms_proxy_pass} | base64 -d | voms-proxy-init \
+                     --voms cms --key /tmp/userkey.pem \
+                     --cert $(readlink -f /etc/reana/secrets/usercert.pem) \
+                     --pwstdin --out {voms_proxy_file_path}; \
+                     chown {kubernetes_uid} {voms_proxy_file_path}'.format(voms_proxy_pass=voms_proxy_pass, \
+                     voms_proxy_file_path=voms_proxy_file_path, kubernetes_uid=self.kubernetes_uid)],
+            'name': current_app.config['VOMSPROXY_CONTAINER_NAME'],
+            'imagePullPolicy': 'IfNotPresent',
+            'volumeMounts': [secrets_volume_mount] + volume_mounts,
+        }
+
+        self.job['spec']['template']['spec']['volumes'].extend(
+            [ticket_cache_volume])
+        self.job['spec']['template']['spec']['containers'][0][
+            'volumeMounts'].extend(volume_mounts)
+
+        # XrootD will look for a valid grid proxy in the location pointed to by the environment variable $X509_USER_PROXY
+        self.job['spec']['template']['spec']['containers'][0][
+            'env'].append({'name': 'X509_USER_PROXY',
+                           'value': voms_proxy_file_path})
+
+        self.job['spec']['template']['spec']['initContainers'].append(
+            voms_proxy_container)
 
     def set_user_id(self, kubernetes_uid):
         """Set user id for job pods. UIDs < 100 are refused for security."""

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -38,5 +38,6 @@ class JobRequest(Schema):
     shared_file_system = fields.Bool(missing=True)
     compute_backend = fields.Str(required=False)
     kerberos = fields.Bool(required=False)
+    voms_proxy = fields.Bool(required=False)
     kubernetes_uid = fields.Int(required=False)
     unpacked_img = fields.Bool(required=False)


### PR DESCRIPTION
Sidecar container that creates a proxy certificate when user specifies `proxy: true` in reana.yaml. The pem files needed to create the certificate is added to reana secrets as files, the password is added as an environment variable

reana-client secrets-add --env VOMSPROXY_PASS=<proxy password in base64>\
                           --file userkey.pem \
                           --file usercert.pem

The security context was before set on pod level to self.kubernetes_uid (default 1000). To read the pem files inside of reana secrets we need root privileges. Set the security context on container level instead at `reana_job_controller/kubernetes_job_manager.py`. Set the job container to self.kubernetes_uid and leave the sidecar as root.

closes reanahub/reana#256