### PR TITLE
job-monitor: logs only from terminated containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - travis_retry pip install -e .[all]
 
 script:
-  - ./run-tests.sh
+  - ./run-tests.sh --include-docker-tests
 
 after_success:
   - coveralls

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This file is part of REANA.
 # Copyright (C) 2017, 2018 CERN.
@@ -6,12 +6,40 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-pydocstyle reana_job_controller && \
-isort -rc -c -df **/*.py && \
-check-manifest --ignore ".travis-*" && \
-FLASK_APP=reana_job_controller/app.py flask openapi create openapi.json  && \
-diff -q openapi.json docs/openapi.json && \
-sphinx-build -qnN docs docs/_build/html && \
-python setup.py test && \
-rm openapi.json && \
-docker build -t reanahub/reana-job-controller .
+COMPONENT_NAME=reana-job-controller
+DOCKER_IMAGE_NAME=reanahub/$COMPONENT_NAME
+PLATFORM="$(python -c 'import platform; print(platform.system())')"
+
+RUN_TESTS="pydocstyle reana_job_controller &&
+isort -rc -c -df **/*.py &&
+check-manifest --ignore '.travis-*' &&
+FLASK_APP=reana_job_controller/app.py flask openapi create openapi.json  &&
+diff -q openapi.json docs/openapi.json &&
+sphinx-build -qnN docs docs/_build/html &&
+python setup.py test &&
+rm openapi.json || exit 1"
+
+case $PLATFORM in
+Darwin*)
+    # Tests are run inside the docker container because there is
+    # no HTCondor Python package for MacOS
+    echo "==> Running tests inside $DOCKER_IMAGE_NAME Docker image ..."
+    docker build -t $DOCKER_IMAGE_NAME .
+    RUN_TESTS_INSIDE_DOCKER="
+    cd $COMPONENT_NAME &&
+    apt install git -y && # Needed by check-manifest
+    pip install --force-reinstall ../reana-commons ../reana-db ../pytest-reana &&
+    pip install .[all] && # Install test dependencies
+    eval $RUN_TESTS"
+    docker run -v $(pwd)/..:/code -ti $DOCKER_IMAGE_NAME bash -c "eval $RUN_TESTS_INSIDE_DOCKER"
+    ;;
+*)
+    echo "==> Running tests locally ..."
+    eval $RUN_TESTS
+    # Test Docker build?
+    if [[ ! "$@" = *"--include-docker-tests"* ]]; then
+        exit 0
+    fi
+    docker build -t $DOCKER_IMAGE_NAME .
+    ;;
+esac

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,13 @@ from __future__ import absolute_import, print_function
 import uuid
 
 import pytest
+from kubernetes.client.models.v1_container_state import V1ContainerState
+from kubernetes.client.models.v1_container_state_terminated import \
+    V1ContainerStateTerminated
+from kubernetes.client.models.v1_container_state_waiting import \
+    V1ContainerStateWaiting
+from kubernetes.client.models.v1_container_status import V1ContainerStatus
+from kubernetes.client.models.v1_pod_status import V1PodStatus
 from mock import MagicMock
 
 from reana_job_controller.factory import create_app
@@ -58,3 +65,64 @@ def base_app(tmp_shared_volume_path):
     }
     app_ = create_app(config_mapping=config_mapping)
     return app_
+
+
+@pytest.fixture
+def kubernetes_job_pod():
+    """Create a mocked Kubernetes job pod."""
+    phases_to_container_state = {
+        'Pending': {
+            'InvalidImageName': V1ContainerState(
+                waiting=V1ContainerStateWaiting(
+                    message=('Failed to apply default image tag "img@#": '
+                             'couldn\'t parse image reference "img@#": '
+                             'invalid reference format'),
+                    reason='InvalidImageName')),
+            'ErrImagePull': V1ContainerState(
+                waiting=V1ContainerStateWaiting(
+                    message=('rpc error: code = Unknown desc = Error '
+                             'response from daemon: pull access denied for '
+                             'private/image, repository does not '
+                             'exist or may require docker login: denied:'
+                             'requested access to the resource is denied'),
+                    reason='ErrImagePull'))
+        },
+        'Succeeded': {
+            'Completed': V1ContainerState(
+                terminated=V1ContainerStateTerminated(exit_code=0,
+                                                      reason='Completed'))
+        },
+        'Failed': {
+            'Error': V1ContainerState(
+                terminated=V1ContainerStateTerminated(exit_code=127,
+                                                      reason='Error'))
+        },
+    }
+
+    def create_job_pod(phase, container_state, init_container_state=None,
+                       job_id=None):
+        job_pod = MagicMock()
+        job_pod.metadata.labels = {'job-name': job_id or str(uuid.uuid4())}
+
+        if phase not in phases_to_container_state.keys():
+            raise ValueError(f'{phase} is not a valid pod phase, '
+                             f'use one of {phases_to_container_state}')
+        job_pod.status = V1PodStatus(phase=phase)
+
+        main_container_status = V1ContainerStatus(
+            image='ubuntu:latest', image_id=str(uuid.uuid4()), ready=False,
+            state=phases_to_container_state[phase][container_state],
+            restart_count=0, name='job')
+
+        job_pod.status.container_statuses = [main_container_status]
+
+        if init_container_state:
+            init_container_status = V1ContainerStatus(
+                image='ubuntu:latest', image_id=str(uuid.uuid4()), ready=False,
+                state=phases_to_container_state[phase][container_state],
+                restart_count=0, name='authz')
+            job_pod.status.init_container_statuses = [init_container_status]
+
+        return job_pod
+
+    return create_job_pod

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -8,6 +8,8 @@
 
 """REANA-Job-Controller Job Monitor tests."""
 
+import uuid
+
 import mock
 import pytest
 
@@ -17,11 +19,100 @@ from reana_job_controller.job_monitor import (JobMonitorHTCondorCERN,
 
 def test_if_singelton(app):
     """Test if job monitor classes are singelton."""
-    with mock.patch("reana_job_controller.job_monitor."
-                    "threading") as threading:
+    with mock.patch("reana_job_controller.job_monitor.threading"):
         first_k8s_instance = JobMonitorKubernetes(app=app)
         second_k8s_instance = JobMonitorKubernetes(app=app)
         assert first_k8s_instance is second_k8s_instance
         first_htc_instance = JobMonitorHTCondorCERN(app=app)
         second_htc_instance = JobMonitorHTCondorCERN(app=app)
         assert first_htc_instance is second_htc_instance
+
+
+@pytest.mark.parametrize(
+    'k8s_phase,k8s_container_state,k8s_logs,pod_logs',
+    [
+        ('Pending', 'ErrImagePull', 'pull access denied', None),
+        ('Pending', 'InvalidImageName', 'couldn\'t parse image', None),
+        ('Succeeded', 'Completed', None, 'job finished'),
+        ('Failed', 'Error', None, 'job failed')
+    ]
+)
+def test_kubernetes_get_job_logs(k8s_phase, k8s_container_state,
+                                 k8s_logs, pod_logs, app,
+                                 kubernetes_job_pod):
+    """Test retrieval of job logs."""
+    k8s_corev1_api_client = mock.MagicMock()
+    k8s_corev1_api_client.read_namespaced_pod_log = lambda **kwargs: pod_logs
+    with mock.patch.multiple(
+            'reana_job_controller.job_monitor',
+            current_k8s_corev1_api_client=k8s_corev1_api_client,
+            threading=mock.DEFAULT):
+        job_monitor_k8s = JobMonitorKubernetes(app=app)
+        job_pod = kubernetes_job_pod(k8s_phase, k8s_container_state)
+        assert (k8s_logs or pod_logs) in job_monitor_k8s.get_job_logs(job_pod)
+
+
+@pytest.mark.parametrize(
+    'k8s_phase,k8s_container_state,expected_reana_status',
+    [
+        ('Pending', 'ErrImagePull', 'failed'),
+        ('Pending', 'InvalidImageName', 'failed'),
+        ('Succeeded', 'Completed', 'succeeded'),
+        ('Failed', 'Error', 'failed')
+    ]
+)
+def test_kubernetes_get_job_status(k8s_phase, k8s_container_state,
+                                   expected_reana_status, app,
+                                   kubernetes_job_pod):
+    """Test retrieval of job status."""
+    with mock.patch("reana_job_controller.job_monitor.threading"):
+        job_monitor_k8s = JobMonitorKubernetes(app=app)
+        job_pod = kubernetes_job_pod(k8s_phase, k8s_container_state)
+        assert job_monitor_k8s.get_job_status(job_pod) == expected_reana_status
+
+
+def test_kubernetes_clean_job(app):
+    """Test clean jobs in the Kubernetes compute backend."""
+    with mock.patch("reana_job_controller.job_monitor."
+                    "threading") as threading:
+        job_monitor_k8s = JobMonitorKubernetes(app=app)
+        job_id = str(uuid.uuid4())
+        job_metadata = {'deleted': False,
+                        'compute_backend': 'kubernetes',
+                        'status': 'succeeded',
+                        'backend_job_id': str(uuid.uuid4())}
+        job_monitor_k8s.job_db = {job_id: job_metadata}
+        with mock.patch("reana_job_controller.job_monitor."
+                        "KubernetesJobManager") as kjm:
+            job_monitor_k8s.clean_job(job_metadata['backend_job_id'])
+            assert kjm.stop.called_once()
+            assert job_monitor_k8s.job_db[job_id]['deleted'] is True
+
+
+@pytest.mark.parametrize(
+    'compute_backend,deleted,should_process',
+    [
+        ('slurm', False, False),
+        ('htcondor', False, False),
+        ('kubernetes', True, False),
+        ('kubernetes', False, True),
+    ]
+)
+def test_kubernetes_should_process_job(app, compute_backend, deleted,
+                                       should_process, kubernetes_job_pod):
+    """Test should process job."""
+    with mock.patch("reana_job_controller.job_monitor."
+                    "threading") as threading:
+        job_monitor_k8s = JobMonitorKubernetes(app=app)
+        job_id = str(uuid.uuid4())
+        backend_job_id = str(uuid.uuid4())
+        job_metadata = {'deleted': deleted,
+                        'compute_backend': compute_backend,
+                        'status': 'succeeded',
+                        'backend_job_id': backend_job_id}
+        job_monitor_k8s.job_db = {job_id: job_metadata}
+        job_pod = kubernetes_job_pod('Succeeded', 'Completed',
+                                     job_id=backend_job_id)
+
+        assert bool(job_monitor_k8s.should_process_job(job_pod)) == \
+            should_process


### PR DESCRIPTION
* On an error scenario inside an init container (usually for
  authentication purposes), job pods were in waiting status
  (`PodInitializing`) as they were waiting for the init container
  to finish, event that would never happen as the init container
  fails. This was causing that a call to Kubernetes to retrieve
  logs of an uninitialised container was fired, resulting in an
  uncatched error and empty logs (close reanahub/reana#284).