### PR TITLE
config: avoid side-effects when loading config

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -10,31 +10,35 @@
 
 import os
 
-from reana_commons.config import (REANA_COMPONENT_PREFIX,
-                                  WORKFLOW_RUNTIME_USER_UID)
-
-from reana_job_controller.htcondorcern_job_manager import \
-    HTCondorJobManagerCERN
-from reana_job_controller.job_monitor import (JobMonitorHTCondorCERN,
-                                              JobMonitorKubernetes,
-                                              JobMonitorSlurmCERN)
-from reana_job_controller.kubernetes_job_manager import KubernetesJobManager
-from reana_job_controller.slurmcern_job_manager import SlurmJobManagerCERN
+from reana_commons.config import REANA_COMPONENT_PREFIX
+from werkzeug.utils import import_string
 
 SHARED_VOLUME_PATH_ROOT = os.getenv('SHARED_VOLUME_PATH_ROOT', '/var/reana')
 """Root path of the shared volume ."""
 
 COMPUTE_BACKENDS = {
-    'kubernetes': KubernetesJobManager,
-    'htcondorcern': HTCondorJobManagerCERN,
-    'slurmcern': SlurmJobManagerCERN
+    'kubernetes': lambda: import_string(
+        'reana_job_controller.kubernetes_job_manager.KubernetesJobManager'
+    ),
+    'htcondorcern': lambda: import_string(
+        'reana_job_controller.htcondorcern_job_manager.JobManagerHTCondorCERN'
+    ),
+    'slurmcern': lambda: import_string(
+        'reana_job_controller.slurmcern_job_manager.SlurmJobManagerCERN'
+    ),
 }
 """Supported job compute backends and corresponding management class."""
 
 JOB_MONITORS = {
-    'kubernetes': JobMonitorKubernetes,
-    'htcondorcern': JobMonitorHTCondorCERN,
-    'slurmcern': JobMonitorSlurmCERN,
+    'kubernetes': lambda: import_string(
+        'reana_job_controller.job_monitor.JobMonitorKubernetes'
+    ),
+    'htcondorcern': lambda: import_string(
+        'reana_job_controller.job_monitor.JobMonitorHTCondorCERN'
+    ),
+    'slurmcern': lambda: import_string(
+        'reana_job_controller.job_monitor.JobMonitorSlurmCERN'
+    ),
 }
 """Classes responsible for monitoring specific backend jobs"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 
 import uuid
 
+import mock
 import pytest
 from kubernetes.client.models.v1_container_state import V1ContainerState
 from kubernetes.client.models.v1_container_state_terminated import \
@@ -126,3 +127,19 @@ def kubernetes_job_pod():
         return job_pod
 
     return create_job_pod
+
+
+@pytest.fixture
+def mocked_job_managers():
+    """Mock and return all Job managers."""
+    kubernetes_job_manager = mock.MagicMock()
+    htcondorcern_job_manager = mock.MagicMock()
+    slurmcern_job_manager = mock.MagicMock()
+    job_managers = {
+        'kubernetes': lambda: kubernetes_job_manager,
+        'htcondorcern': lambda: htcondorcern_job_manager,
+        'slurmcern': lambda: slurmcern_job_manager,
+    }
+    with mock.patch("reana_job_controller.job_monitor."
+                    "COMPUTE_BACKENDS", job_managers):
+        yield job_managers


### PR DESCRIPTION
* Currently backend specific code was being loaded at import config
  time, causing errors when necessary HTCondor was not available
  because user workflows were requesting just Kubernetes jobs.