### PR TITLE
config: use central optional hostpath mounts

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -46,31 +46,6 @@ JOB_MONITORS = {
 DEFAULT_COMPUTE_BACKEND = "kubernetes"
 """Default job compute backend."""
 
-JOB_HOSTPATH_MOUNTS = []
-"""List of tuples composed of name and path to create hostPath's inside jobs.
-
-This configuration should be used only when one knows for sure that the
-specified locations exist in all the cluster nodes.
-
-For example, if you are running REANA on Minikube with a single VM you would
-have to mount in Minikube the volume you want to be attached to every job:
-
-.. code-block::
-
-    $ minikube mount /usr/local/share/mydata:/mydata
-
-And add the following configuration to REANA-Job-Controller:
-
-.. code-block::
-
-    JOB_HOSTPATH_MOUNTS = [
-        ('mydata', '/mydata'),
-    ]
-
-This way all jobs will have ``/mydata`` mounted with the content of
-``/usr/local/share/mydata`` in the host machine.
-"""
-
 SUPPORTED_COMPUTE_BACKENDS = os.getenv(
     "COMPUTE_BACKENDS", DEFAULT_COMPUTE_BACKEND
 ).split(",")

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -23,6 +23,7 @@ from reana_commons.config import (
     K8S_CERN_EOS_AVAILABLE,
     K8S_CERN_EOS_MOUNT_CONFIGURATION,
     REANA_COMPONENT_PREFIX,
+    REANA_JOB_HOSTPATH_MOUNTS,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_UID,
@@ -256,9 +257,12 @@ class KubernetesJobManager(JobManager):
     def add_hostpath_volumes(self):
         """Add hostPath mounts from configuration to job."""
         volumes_to_mount = []
-        for name, path in current_app.config["JOB_HOSTPATH_MOUNTS"]:
-            volume_mount = {"name": name, "mountPath": path}
-            volume = {"name": name, "hostPath": {"path": path}}
+        for mount in REANA_JOB_HOSTPATH_MOUNTS:
+            volume_mount = {
+                "name": mount["name"],
+                "mountPath": mount.get("mountPath", mount["hostPath"]),
+            }
+            volume = {"name": mount["name"], "hostPath": {"path": mount["hostPath"]}}
             volumes_to_mount.append((volume_mount, volume))
 
         self.add_volumes(volumes_to_mount)


### PR DESCRIPTION
* The format of this configuration gets updated to provide flexibility
  regarding where to mount the volumes inside the jobs, with the
  `mountPath` field.