### PR TITLE
docs: autodoc_mock_imports for gssapi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include LICENSE
 include *.rst
 include *.sh
 include *.txt
+include *.in
 include pytest.ini
 include docs/openapi.json
 include docs/_static/reana-job-manager.xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,9 @@ extensions = [
     "sphinxcontrib.redoc",
 ]
 
+# Autodoc mocking to fix ReadTheDocs builds missing system dependencies
+autodoc_mock_imports = ["gssapi", "paramiko[gssapi]"]
+
 redoc = [
     {
         "page": "_static/api",

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -13,7 +13,6 @@ import os
 import subprocess
 import sys
 
-import paramiko
 from reana_db.database import Session
 from reana_db.models import Workflow
 
@@ -72,6 +71,8 @@ def initialize_krb5_token(workflow_uuid):
 class SSHClient:
     """SSH Client."""
 
+    import paramiko
+
     def __init__(self, hostname=None, port=None):
         """Initialize ssh client."""
         self.hostname = hostname
@@ -80,8 +81,8 @@ class SSHClient:
 
     def establish_connection(self):
         """Establish the connection."""
-        self.ssh_client = paramiko.SSHClient()
-        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh_client = self.paramiko.SSHClient()
+        self.ssh_client.set_missing_host_key_policy(self.paramiko.AutoAddPolicy())
         self.ssh_client.connect(hostname=self.hostname, port=self.port, gss_auth=True)
 
     def exec_command(self, command):

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018 CERN.
+# Copyright (C) 2020 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
--e .[docs]
+paramiko[gssapi]==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ monotonic==1.5            # via bravado
 msgpack-python==0.5.6     # via bravado
 msgpack==1.0.0            # via bravado-core
 oauthlib==3.1.0           # via requests-oauthlib
-paramiko[gssapi]==2.7.1   # via reana-job-controller (setup.py)
+paramiko[gssapi]==2.7.1   # via -r requirements.in
 psycopg2-binary==2.8.5    # via reana-db
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via paramiko, pyasn1-modules, rsa

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "tests": tests_require,
+    "ssh": ["paramiko[gssapi]>=2.6.0"]
 }
 
 extras_require["all"] = []
@@ -54,7 +55,6 @@ install_requires = [
     "reana-db>=0.7.0a6,<0.8.0",
     "htcondor==8.9.7",
     "retrying>=1.3.3",
-    "paramiko[gssapi]>=2.6.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
closes #274

Adds mocking of  `gssapi` that cannot be installed on ReadTheDocs
builders.

This fixes the ReadTheDocs building problem.
