### PR TITLE
Htc resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.7.1 (UNRELEASED)
+--------------------------
+
+- Allows ``htcondor_max_runtime`` and ``htcondor_accounting_group`` to be specified for HTC jobs.
+
 Version 0.7.0 (2020-10-20)
 --------------------------
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -57,6 +57,12 @@
           "default": {},
           "type": "object"
         },
+        "htcondor_accounting_group": {
+          "type": "string"
+        },
+        "htcondor_max_runtime": {
+          "type": "string"
+        },
         "job_name": {
           "type": "string"
         },

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -41,3 +41,5 @@ class JobRequest(Schema):
     voms_proxy = fields.Bool(required=False)
     kubernetes_uid = fields.Int(required=False)
     unpacked_img = fields.Bool(required=False)
+    htcondor_max_runtime = fields.Str(required=False)
+    htcondor_accounting_group = fields.Str(required=False)


### PR DESCRIPTION
Add `htcondor_max_runtime` and `htcondor_accounting_group`

Following HTCondor's example max runtime can either be set directly in seconds, or can be assigned a "flavour" which will bucket the job into a max runtime. Job flavours can be found [here](https://batchdocs.web.cern.ch/local/submit.html).

Closes reanahub/reana-job-controller#32