### PR TITLE
kubernetes: do not mount K8S API token on jobs

### DIFF
--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -119,6 +119,7 @@ class KubernetesJobManager(JobManager):
                 "namespace": REANA_RUNTIME_KUBERNETES_NAMESPACE,
             },
             "spec": {
+                "automountServiceAccountToken": False,
                 "backoffLimit": KubernetesJobManager.MAX_NUM_JOB_RESTARTS,
                 "autoSelector": True,
                 "template": {


### PR DESCRIPTION
* Avoids default automounting of Kubernetes API tokens inside
  user jobs (more [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server))
  as it may represent a security hazard.