### PR TITLE
htcondor: retrieve files always

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.7.3 (UNRELEASED)
 
 - Adds new configuration to toggle Kubernetes user jobs clean up.
 - Fixes HTCondor Docker networking and machine version requirement setup.
+- Fixes HTCondor logs and workspace files retrieval on job failure.
 - Fixes Slurm job submission providing the correct shell environment to run Singularity.
 - Changes HTCondor myschedd to the latest version.
 - Changes job status ``succeeded`` to ``finished`` to use central REANA nomenclature.

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -348,10 +348,6 @@ class JobMonitorHTCondorCERN(JobMonitor):
                             "ExitCode", condor_job.get("ExitStatus")
                         )
                         if exit_code == 0:
-                            app.htcondor_executor.submit(
-                                self.job_manager_cls.spool_output,
-                                job_dict["backend_job_id"],
-                            )
                             job_db[job_id]["status"] = "finished"
                         else:
                             logging.info(
@@ -359,6 +355,10 @@ class JobMonitorHTCondorCERN(JobMonitor):
                                 "failed".format(job_id, condor_job["ClusterId"])
                             )
                             job_db[job_id]["status"] = "failed"
+                        app.htcondor_executor.submit(
+                            self.job_manager_cls.spool_output,
+                            job_dict["backend_job_id"],
+                        ).result()
                         job_logs = app.htcondor_executor.submit(
                             self.job_manager_cls.get_logs,
                             job_dict["backend_job_id"],


### PR DESCRIPTION
* The workspace of HTCondor jobs was not retrieved in case of job
  failure, causing error "file not found *.err *.out" when trying
  to store logs to later display to the user (closes #301).

Closes #301.