### PR TITLE
slurm: fix variables and doc-string typos

### DIFF
--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -182,19 +182,19 @@ class SlurmJobManagerCERN(JobManager):
         )
         return base_singularity_cmd
 
-    def get_outputs():
+    def get_outputs(self):
         """Transfer job outputs to REANA."""
         os.chdir(SlurmJobManagerCERN.REANA_WORKSPACE_PATH)
         slurm_connection = SSHClient()
         sftp = slurm_connection.ssh_client.open_sftp()
-        SlurmJobManagerCERN._download_dir(
+        self._download_dir(
             sftp,
             SlurmJobManagerCERN.SLURM_WORKSPACE_PATH,
             SlurmJobManagerCERN.REANA_WORKSPACE_PATH,
         )
         sftp.close()
 
-    def _download_dir(sftp, remote_dir, local_dir):
+    def _download_dir(self, sftp, remote_dir, local_dir):
         """Download remote directory content."""
         os.path.exists(local_dir) or os.makedirs(local_dir)
         dir_items = sftp.listdir_attr(remote_dir)
@@ -202,11 +202,11 @@ class SlurmJobManagerCERN(JobManager):
             remote_path = os.path.join(remote_dir, item.filename)
             local_path = os.path.join(local_dir, item.filename)
             if S_ISDIR(item.st_mode):
-                SlurmJobManagerCERN._download_dir(sftp, remote_path, local_path)
+                self._download_dir(sftp, remote_path, local_path)
             else:
                 sftp.get(remote_path, local_path)
 
-    def get_logs(backend_job_id, workspace):
+    def get_logs(self, backend_job_id, workspace):
         """Return job logs if log files are present."""
         stderr_file = os.path.join(
             workspace, "reana_job." + str(backend_job_id) + ".err"

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -54,12 +54,12 @@ class SlurmJobManagerCERN(JobManager):
         :type docker_img: str
         :param cmd: Command to execute.
         :type cmd: list
-        :param prettified_cmd: pretified version of command to execute.
+        :param prettified_cmd: prettified version of command to execute.
         :type prettified_cmd: str
         :param env_vars: Environment variables.
         :type env_vars: dict
-        :param workflow_id: Unique workflow id.
-        :type workflow_id: str
+        :param workflow_uuid: Unique workflow id.
+        :type workflow_uuid: str
         :param workflow_workspace: Workflow workspace path.
         :type workflow_workspace: str
         :param cvmfs_mounts: list of CVMFS mounts as a string.
@@ -170,7 +170,7 @@ class SlurmJobManagerCERN(JobManager):
         return "echo {}|base64 -d|bash".format(encoded_cmd)
 
     def _wrap_singularity_cmd(self):
-        """Wrap command in singulrity."""
+        """Wrap command in singularity."""
         base_singularity_cmd = (
             "singularity exec -B {SLURM_WORKSPACE}:{REANA_WORKSPACE}"
             " docker://{DOCKER_IMG} {CMD}".format(


### PR DESCRIPTION
This PR addresses variables and doc-string typos found in the [slurmcern_job_controller.py](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/slurmcern_job_manager.py) module. In addition, there were some methods missing the standard `self` argument.

There may be a more relevant PR coming soon, as we are trying to deploy REANA with Slurm at NYU, and so far have encountered some issues on `multistage-step` workflows that deal with files.