### PR TITLE
k8s: allow customising job memory limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.7.4 (UNRELEASED)
 
 - Adds configuration environment variable to set job memory limits for the Kubernetes compute backend (``REANA_KUBERNETES_JOBS_MEMORY_LIMIT``).
 - Fixes Kubernetes job log capture to include information about failures caused by external factors such as OOMKilled.
+- Adds support for specifying ``kubernetes_memory_limit`` for Kubernetes compute backend jobs.
 
 Version 0.7.3 (2021-03-17)
 --------------------------

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -69,6 +69,9 @@
         "kerberos": {
           "type": "boolean"
         },
+        "kubernetes_memory_limit": {
+          "type": "string"
+        },
         "kubernetes_uid": {
           "format": "int32",
           "type": "integer"

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -93,7 +93,17 @@ IMAGE_PULL_SECRETS = os.getenv("IMAGE_PULL_SECRETS", "").split(",")
 """Docker image pull secrets which allow the usage of private images."""
 
 REANA_KUBERNETES_JOBS_MEMORY_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_LIMIT")
-"""Maximum memory limit for user job containers. Exceeding this limit will terminate the container.
+"""Maximum default memory limit for user job containers. Exceeding this limit will terminate the container.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.
+"""
+
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT"
+)
+"""Maximum custom memory limit that users can assign to their job containers via
+``kubernetes_memory_limit`` in reana.yaml. Exceeding this limit will terminate the container.
 
 Please see the following URL for possible values
 https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -41,6 +41,7 @@ class JobRequest(Schema):
     kerberos = fields.Bool(required=False)
     voms_proxy = fields.Bool(required=False)
     kubernetes_uid = fields.Int(required=False)
+    kubernetes_memory_limit = fields.Str(required=False)
     unpacked_img = fields.Bool(required=False)
     htcondor_max_runtime = fields.Str(required=False)
     htcondor_accounting_group = fields.Str(required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ python-dateutil==2.8.1    # via alembic, bravado, bravado-core, kubernetes
 python-editor==1.0.4      # via alembic
 pytz==2020.1              # via bravado-core, fs
 pyyaml==5.3.1             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.7.4  # via reana-db, reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.7.5a2  # via reana-db, reana-job-controller (setup.py)
 reana-db==0.7.3           # via reana-job-controller (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.24.0          # via bravado, kubernetes, requests-oauthlib

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     "werkzeug>=0.16.1,<0.17",
     "fs>=2.0",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes]>=0.7.4,<0.8.0",
+    "reana-commons[kubernetes]>=0.7.5a2,<0.8.0",
     "reana-db>=0.7.3,<0.8.0",
     "htcondor==8.9.7",
     "retrying>=1.3.3",

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -18,7 +18,6 @@ from reana_db.models import Job, JobStatus
 
 from reana_job_controller.job_manager import JobManager
 from reana_job_controller.kubernetes_job_manager import KubernetesJobManager
-from reana_job_controller.utils import validate_kubernetes_memory
 
 
 def test_execute_kubernetes_job(
@@ -137,27 +136,3 @@ def test_execution_hooks():
     job_manager = TestJobManger("busybox", "ls", {})
     job_manager.execute()
     assert job_manager.order_list == [1, 2, 3, 4]
-
-
-@pytest.mark.parametrize(
-    "memory,output",
-    [
-        ("100K", True),
-        ("8Mi", True),
-        ("7Gi", True),
-        ("3T", True),
-        ("50Pi", True),
-        ("2Ei", True),
-        ("1E", True),
-        ("2KI", False),
-        ("4096KiB", False),
-        ("8Kib", False),
-        ("8Mb", False),
-        ("2GB", False),
-        ("50Tb", False),
-        ("24Exabyte", False),
-    ],
-)
-def test_validate_kubernetes_memory_format(memory, output):
-    """Test validation of K8s memory format."""
-    assert validate_kubernetes_memory(memory) is output

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -18,6 +18,7 @@ from reana_db.models import Job, JobStatus
 
 from reana_job_controller.job_manager import JobManager
 from reana_job_controller.kubernetes_job_manager import KubernetesJobManager
+from reana_job_controller.utils import validate_kubernetes_memory
 
 
 def test_execute_kubernetes_job(
@@ -136,3 +137,27 @@ def test_execution_hooks():
     job_manager = TestJobManger("busybox", "ls", {})
     job_manager.execute()
     assert job_manager.order_list == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    "memory,output",
+    [
+        ("100K", True),
+        ("8Mi", True),
+        ("7Gi", True),
+        ("3T", True),
+        ("50Pi", True),
+        ("2Ei", True),
+        ("1E", True),
+        ("2KI", False),
+        ("4096KiB", False),
+        ("8Kib", False),
+        ("8Mb", False),
+        ("2GB", False),
+        ("50Tb", False),
+        ("24Exabyte", False),
+    ],
+)
+def test_validate_kubernetes_memory_format(memory, output):
+    """Test validation of K8s memory format."""
+    assert validate_kubernetes_memory(memory) is output


### PR DESCRIPTION
closes reanahub/reana-client#496
 
⚠️ Tests failing due to missing `reana-commons` release.

#### To test

- Set a cluster-wide memory limit to verify that is override. If you don't have a multinode cluster setup, comment out the check that forces you to have `node_label_runtime` when setting `kubernetes_jobs_memory_limit`:

```diff
diff --git a/helm/reana/templates/reana-workflow-controller.yaml b/helm/reana/templates/reana-workflow-controller.yaml
index c565512..c35b77c 100644
--- a/helm/reana/templates/reana-workflow-controller.yaml
+++ b/helm/reana/templates/reana-workflow-controller.yaml
@@ -80,7 +80,6 @@ spec:
             value: {{ .Values.node_label_runtime }}
           {{- end }}
           {{- if .Values.kubernetes_jobs_memory_limit }}
-          {{- $_ := required "In order to use .Values.kubernetes_jobs_memory_limit safely you should set the label .Values.node_label_runtime and label a node with it." .Values.node_label_runtime }}
           - name: REANA_KUBERNETES_JOBS_MEMORY_LIMIT
             value: {{ .Values.kubernetes_jobs_memory_limit }}
           {{- end }}
diff --git a/helm/reana/values.yaml b/helm/reana/values.yaml
index c5bfe9e..dff83db 100644
--- a/helm/reana/values.yaml
+++ b/helm/reana/values.yaml
@@ -114,3 +114,6 @@ traefik:
   ssl:
     enabled: true
     generateTLS: true
+
+
+kubernetes_jobs_memory_limit: 4Gi

```

- Taking `reana-demo-helloworld` as example, modify command to force memory usage and set a low kubernetes memory limit:
```diff
diff --git a/reana.yaml b/reana.yaml
index 50d1bd8..056d332 100644
--- a/reana.yaml
+++ b/reana.yaml
@@ -13,11 +13,9 @@ workflow:
   specification:
     steps:
       - environment: 'python:2.7-slim'
+        kubernetes_memory_limit: '200Mi'
         commands:
-          - python "${helloworld}"
-              --inputfile "${inputfile}"
-              --outputfile "${outputfile}"
-              --sleeptime ${sleeptime}
+          - python -c 'import os; [os.urandom(1024*1024) for x in xrange(1024)]'
 outputs:
   files:
    - results/greetings.txt
```

⚠️ If you are using macOS, take into account the amount of swap memory you have assign to your Docker daemon as Kind will always try to overcommit it. E.g If you have 512Mi of Swap, the memory used (~1Gi in the previous example) must be greater than `kubernetes_memory_limit` (200Mi) + swap (512Mi). 1Gi > 712Mi ==> OOMKilled.

- Run workflow
```console
$ reana-client run -w hello
```

- Check node status to verify that job memory limit is correct.

```console
$ kubectl describe nodes kind-control-plane
...
Non-terminated Pods:          (20 in total)        
Namespace                   Name                                                          CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE  
  ---------                   ----                                                          ------------  ----------  ---------------  -------------  ---          
...
default                     reana-run-job-134cb10e-860e-495a-906b-1eb939c5cb84-ct6p7      0 (0%)        0 (0%)      200Mi (0%)        200Mi (0%)      18s

```        

- Check that the workflows was `OOMKilled.
```console
$ kubectl get pods | grep reana-run-job                                                          
reana-run-job-134cb10e-860e-495a-906b-1eb939c5cb84-ct6p7     0/1     OOMKilled   0          44m

$ reana-client logs -w hello
==> Job logs
==> Step: 41d2b53f-c66d-4fb4-b5dd-03c7395aac54
==> Workflow ID: 8f4c17c9-b3e8-4cbc-bd85-77b031082252
==> Compute backend: Kubernetes
==> Job ID: reana-run-job-134cb10e-860e-495a-906b-1eb939c5cb84
==> Docker image: python:2.7-slim
==> Command: python -c 'import os; [os.urandom(1024*1024) for x in xrange(1024)]'
==> Status: failed
==> Logs:
job: :
 

OOMKilled

```

- In order to test **only** server-side validation of memory limits, there're two options: 
  - Run yardage workflows as JSON Schema allows any vale for `kubernetes_memory_limit` under resources, so server-side will take care.
  - Comment out the `pattern` validation for serial workflows [here](https://github.com/reanahub/reana-commons/pull/256/files#diff-d42b5fb5c5eeb326eddbc6deaca8c11bc16bcc42b7e5f7db9899513e61d92941R66). 