### PR TITLE
htcondorcern: upgrade to 8.9.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.7.5 (UNRELEASED)
+--------------------------
+
+- Changes HTCondor to 8.9.11.
+- Changes myschedd package and configuration to latest versions.
+
 Version 0.7.4 (2021-04-28)
 --------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN if echo "$COMPUTE_BACKENDS" | grep -q "htcondorcern"; then \
       set -e;\
       export DEBIAN_FRONTEND=noninteractive ;\
       apt-get -yq install --no-install-recommends wget alien gnupg2 ;\
-      wget -O ngbauth-submit.rpm http://linuxsoft.cern.ch/internal/repos/batch7-stable/x86_64/os/Packages/ngbauth-submit-0.23-2.el7.noarch.rpm; \
-      wget -O myschedd.rpm http://linuxsoft.cern.ch/internal/repos/batch7-stable/x86_64/os/Packages/myschedd-1.7-1.el7.x86_64.rpm; \
+      wget -O ngbauth-submit.rpm http://linuxsoft.cern.ch/internal/repos/batch7-stable/x86_64/os/Packages/ngbauth-submit-0.24-3.el7.noarch.rpm; \
+      wget -O myschedd.rpm http://linuxsoft.cern.ch/internal/repos/batch7-stable/x86_64/os/Packages/myschedd-1.7-2.el7.x86_64.rpm; \
       yes | alien -i myschedd.rpm; \
       yes | alien -i ngbauth-submit.rpm; \
       wget -qO - http://research.cs.wisc.edu/htcondor/debian/HTCondor-Release.gpg.key | apt-key add -; \

--- a/etc/myschedd.yaml
+++ b/etc/myschedd.yaml
@@ -8,17 +8,17 @@ pools:
   share:
     standard:
       - bigbird08.cern.ch
-      - bigbird09.cern.ch
       - bigbird10.cern.ch
       - bigbird11.cern.ch
       - bigbird12.cern.ch
       - bigbird13.cern.ch
       - bigbird14.cern.ch
-      - bigbird15.cern.ch
       - bigbird16.cern.ch
       - bigbird17.cern.ch
       - bigbird18.cern.ch
       - bigbird19.cern.ch
+      - bigbird22.cern.ch
+      - bigbird23.cern.ch
   tzero:
     standard:
       - tbird02.cern.ch

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -108,9 +108,6 @@ class HTCondorJobManagerCERN(JobManager):
         """Execute / submit a job with HTCondor."""
         os.chdir(self.workflow_workspace)
         job_ad = classad.ClassAd()
-        job_ad["Requirements"] = classad.ExprTree(
-            'regexp("8.9.11", TARGET.CondorVersion)'
-        )
         job_ad["JobDescription"] = (
             self.workflow.get_full_workflow_name() + "_" + self.job_name
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ flask==1.1.2              # via reana-job-controller (setup.py)
 fs==2.4.11                # via reana-job-controller (setup.py)
 google-auth==1.20.1       # via kubernetes
 gssapi==1.6.9             # via paramiko
-htcondor==8.9.7           # via reana-job-controller (setup.py)
+htcondor==8.9.11          # via reana-job-controller (setup.py)
 idna==2.10                # via jsonschema, requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "reana-commons[kubernetes]>=0.7.5a2,<0.8.0",
     "reana-db>=0.7.3,<0.8.0",
-    "htcondor==8.9.7",
+    "htcondor==8.9.11",
     "retrying>=1.3.3",
 ]
 


### PR DESCRIPTION
Upgrades HTCondor to 8.9.11, following up the upgrade of CERN HTCondor
cluster.

Removes ClassAd HTCondor version constraint that is no longer necessary.

Updates myschedd package and configuration to latest LXPLUS values.

Updates ngbauth-submit package to latest LXPLUS value.