### PR TITLE
htcondorcern: fixed job command formatting issue for CWL workflows

### DIFF
--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -166,7 +166,7 @@ class HTCondorJobManagerCERN(JobManager):
             # E.g. "cd /path/to/workspace ; user-command" -> "user-command"
             base_cmd = " ".join(self.cmd.split()[3:])
         elif self.workflow.type_ == "cwl":
-            base_cmd = self.cmd[2].replace(self.workflow_workspace, "$_CONDOR_JOB_IWD")
+            base_cmd = self.cmd.replace(self.workflow_workspace, "$_CONDOR_JOB_IWD")
         elif self.workflow.type_ == "yadage":
             if "base64" in self.cmd:
                 # E.g. echo ZWNobyAxCg==|base64 -d|bash


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-engine-cwl/issues/186

CWL job commands are [formatted as strings](https://github.com/reanahub/reana-workflow-engine-cwl/blob/master/reana_workflow_engine_cwl/cwl_reana.py#L254) in `reana-workflow-engine-cwl`, but `htcondorcern_job_manager (reana-job-controller)` [expected a list here](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/htcondorcern_job_manager.py#L169). 
That's why the error was `i: command not found`, since the second element of job command string `"/bin/sh...."` is `i`.

With this fix `reana-demo-helloworld/reana-cwl-htcondorcern.yaml` example worked as expected