### PR TITLE
rest: catch and expose DB connection troubles

### DIFF
--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -13,6 +13,7 @@ import json
 import logging
 
 from flask import Blueprint, current_app, jsonify, request
+from sqlalchemy.exc import OperationalError
 from reana_commons.errors import (
     REANAKubernetesMemoryLimitExceeded,
     REANAKubernetesWrongMemoryFormat,
@@ -225,7 +226,16 @@ def create_job():  # noqa
             return jsonify({"message": e.message}), 403
         except REANAKubernetesWrongMemoryFormat as e:
             return jsonify({"message": e.message}), 400
-    backend_jod_id = job_obj.execute()
+    try:
+        backend_jod_id = job_obj.execute()
+    except OperationalError as e:
+        msg = f"Job submission failed because of DB connection issues. \n{e}"
+        logging.error(msg, exc_info=True)
+        return jsonify({"message": msg}), 500
+    except Exception as e:
+        msg = f"Job submission failed. \n{e}"
+        logging.error(msg, exc_info=True)
+        return jsonify({"message": msg}), 500
     if job_obj:
         job = copy.deepcopy(job_request)
         job["status"] = "started"


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-controller/issues/408

To test:
- Change [max-connections](https://github.com/reanahub/reana/blob/master/helm/reana/templates/reana-db.yaml#L37) value to 5 and redeploy the cluster
- Run `helloworld` demo and check the logs:
```
reana ❯ rc logs -w workflow.1
==> Workflow engine logs
Workflow exited unexpectedly.
Job submission error: Job submission failed because of DB connection issues.
(psycopg2.OperationalError) FATAL:  sorry, too many clients already

(Background on this error at: http://sqlalche.me/e/13/e3q8)
```
