### PR TITLE
db: close db connections after each request

### DIFF
--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -9,11 +9,9 @@
 """Job Manager."""
 
 import json
-import shlex
 
-from flask import current_app
 from reana_commons.utils import calculate_file_access_time
-from reana_db.database import Session
+from reana_db.database import Session, engine as db_engine
 from reana_db.models import Job as JobTable
 from reana_db.models import JobCache, JobStatus, Workflow
 
@@ -64,6 +62,7 @@ class JobManager:
             backend_job_id = fn(inst, *args, **kwargs)
             inst.create_job_in_db(backend_job_id)
             inst.cache_job()
+            db_engine.dispose()
             return backend_job_id
 
         return wrapper


### PR DESCRIPTION
close https://github.com/reanahub/reana-job-controller/issues/325

The problem was that `job-controller` started a new DB session on initial job creation and removed the connection only when the app [was terminated](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/factory.py#L43). This lead to creation of multiple db connections while launching many workflows and it meant that we can only launch as many workflows in parallel as we have [db connections](https://github.com/reanahub/reana/pull/542).

This PR tries to release the DB connection as soon as it is no longer needed: after each request and especially after [job registration in the DB](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/job_manager.py#L65-L66) (main operation)

One possible way to test is to use `reana_bench.py` script and inspect the DB connections:
- Deploy the cluster with:
  ```
  REANA_MAX_CONCURRENT_BATCH_WORKFLOWS: 100
  REANA_SCHEDULER_REQUEUE_SLEEP: 0
  ```
  (make sure it will not be overrided by [this line](https://github.com/reanahub/reana/blob/master/helm/configurations/values-dev.yaml#L7) as it happened to me :)

- Launch 50 roofit yadage workflows:
  ```
  python reana_bench.py launch -w roofit50yadage-n 50 -f reana-yadage.yaml
  ```

- While it is running inspect DB connections:
  ```
  kubectl exec -i -t deployment/reana-db -- psql -U reana -c "SELECT * FROM pg_stat_activity WHERE datname='reana';"
  ```

Observations:
- Test performed **without the PR** created 55 DB connections (50 spawned from job-controller + 5 infrastructure sessions) and DB connections were cleaned only after `run-batch` pods were terminated (on app teardown)
- Test performed **with this PR** created ~25 DB connections maximum which lasted only a fraction of a second and was reduced shortly. In general DB connections were released way before `run-batch` pods were terminated
