### PR TITLE
job-monitor: rename job pod labels to be in line with run batch labels

### DIFF
--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -243,7 +243,7 @@ class JobMonitorKubernetes(JobMonitor):
                 for event in w.stream(
                     current_k8s_corev1_api_client.list_namespaced_pod,
                     namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
-                    label_selector=f"reana-workflow-uuid={self.workflow_uuid}",
+                    label_selector=f"reana-run-job-workflow-uuid={self.workflow_uuid}",
                 ):
                     logging.info("New Pod event received: {0}".format(event["type"]))
                     job_pod = event["object"]

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -147,7 +147,7 @@ class KubernetesJobManager(JobManager):
                 "template": {
                     "metadata": {
                         "name": backend_job_id,
-                        "labels": {"reana-workflow-uuid": self.workflow_uuid},
+                        "labels": {"reana-run-job-workflow-uuid": self.workflow_uuid},
                     },
                     "spec": {
                         "containers": [


### PR DESCRIPTION
Context: https://github.com/reanahub/reana-workflow-controller/pull/417#discussion_r742147129