### PR TITLE
slurm: expose some of the job configuration to users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.0 (UNRELEASED)
+--------------------------
+
+- Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
+
 Version 0.8.1 (2022-02-07)
 ---------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 --------------------------
 
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
+- Changes default Slurm partition to ``inf-short``.
 
 Version 0.8.1 (2022-02-07)
 ---------------------------

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -88,6 +88,12 @@
           "default": true,
           "type": "boolean"
         },
+        "slurm_partition": {
+          "type": "string"
+        },
+        "slurm_time": {
+          "type": "string"
+        },
         "unpacked_img": {
           "type": "boolean"
         },

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -104,3 +104,30 @@ REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
 Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
 """
+
+SLURM_HEADNODE_HOSTNAME = os.getenv("SLURM_HOSTNAME", "hpc-batch.cern.ch")
+"""Hostname of SLURM head-node used for job management via SSH."""
+
+SLURM_HEADNODE_PORT = os.getenv("SLURM_CLUSTER_PORT", "22")
+"""Port of SLURM head node."""
+
+SLURM_PARTITION = os.getenv("SLURM_PARTITION", "inf-short")
+"""Default slurm partition."""
+
+SLURM_JOB_TIMELIMIT = os.getenv("SLURM_JOB_TIMELIMIT", "60")
+"""Default SLURM job timelimit.
+
+Acceptable time formats include "minutes", "minutes:seconds", "hours:minutes:seconds", "days-hours",
+"days-hours:minutes" and "days-hours:minutes:seconds". A time limit of zero means that no time limit
+will be imposed. Please see the following URL for more details
+https://slurm.schedmd.com/sbatch.html (-t, --time)
+"""
+
+SLURM_SSH_TIMEOUT = float(os.getenv("SLURM_SSH_TIMEOUT", "60"))
+"""Seconds to wait for SLURM SSH TCP connection."""
+
+SLURM_SSH_BANNER_TIMEOUT = float(os.getenv("SLURM_SSH_BANNER_TIMEOUT", "60"))
+"""Seconds to wait for SLURM SSH banner to be presented."""
+
+SLURM_SSH_AUTH_TIMEOUT = float(os.getenv("SLURM_SSH_AUTH_TIMEOUT", "60"))
+"""Seconds to wait for SLURM SSH authentication response."""

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -20,7 +20,14 @@ from reana_commons.k8s.api_client import current_k8s_corev1_api_client
 from reana_db.database import Session
 from reana_db.models import Job, JobStatus
 
-from reana_job_controller.config import COMPUTE_BACKENDS
+from reana_job_controller.config import (
+    COMPUTE_BACKENDS,
+    SLURM_HEADNODE_HOSTNAME,
+    SLURM_HEADNODE_PORT,
+    SLURM_SSH_TIMEOUT,
+    SLURM_SSH_BANNER_TIMEOUT,
+    SLURM_SSH_AUTH_TIMEOUT,
+)
 from reana_job_controller.job_db import JOB_DB
 from reana_job_controller.utils import SSHClient, singleton
 
@@ -458,8 +465,11 @@ class JobMonitorSlurmCERN(JobMonitor):
         :param job_db: Dictionary which contains all running jobs.
         """
         slurm_connection = SSHClient(
-            hostname=self.job_manager_cls.SLURM_HEADNODE_HOSTNAME,
-            port=self.job_manager_cls.SLURM_HEADNODE_PORT,
+            hostname=SLURM_HEADNODE_HOSTNAME,
+            port=SLURM_HEADNODE_PORT,
+            timeout=SLURM_SSH_TIMEOUT,
+            banner_timeout=SLURM_SSH_BANNER_TIMEOUT,
+            auth_timeout=SLURM_SSH_AUTH_TIMEOUT,
         )
         statuses_to_skip = ["finished", "failed"]
         while True:

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -51,6 +51,8 @@ class JobRequest(Schema):
     unpacked_img = fields.Bool(required=False)
     htcondor_max_runtime = fields.Str(required=False)
     htcondor_accounting_group = fields.Str(required=False)
+    slurm_partition = fields.Str(required=False)
+    slurm_time = fields.Str(required=False)
 
     @pre_load
     def set_kubernetes_job_timeout(self, in_data, **kwargs):

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -26,7 +26,7 @@ class SlurmJobManagerCERN(JobManager):
     """Hostname of SLURM head-node used for job management via SSH."""
     SLURM_HEADNODE_PORT = os.getenv("SLURM_CLUSTER_PORT", "22")
     """Port of SLURM head node."""
-    SLURM_PARTITION = os.getenv("SLURM_PARTITION", "batch-short")
+    SLURM_PARTITION = os.getenv("SLURM_PARTITION", "inf-short")
     """Default slurm partition."""
     SLURM_HOME_PATH = os.getenv("SLURM_HOME_PATH", "")
     """Default SLURM home path."""

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017-2019 CERN.
+# Copyright (C) 2017-2019, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -45,6 +45,7 @@ def initialize_krb5_token(workflow_uuid):
     cern_user = os.environ.get("CERN_USER")
     keytab_file = os.environ.get("CERN_KEYTAB")
     cmd = "kinit -kt /etc/reana/secrets/{} {}@CERN.CH".format(keytab_file, cern_user)
+
     if cern_user:
         try:
             subprocess.check_output(cmd, shell=True)
@@ -73,17 +74,34 @@ class SSHClient:
 
     import paramiko
 
-    def __init__(self, hostname=None, port=None):
+    def __init__(
+        self,
+        hostname=None,
+        port=None,
+        timeout=None,
+        banner_timeout=None,
+        auth_timeout=None,
+    ):
         """Initialize ssh client."""
         self.hostname = hostname
         self.port = port
+        self.timeout = timeout
+        self.banner_timeout = banner_timeout
+        self.auth_timeout = auth_timeout
         self.establish_connection()
 
     def establish_connection(self):
         """Establish the connection."""
         self.ssh_client = self.paramiko.SSHClient()
         self.ssh_client.set_missing_host_key_policy(self.paramiko.AutoAddPolicy())
-        self.ssh_client.connect(hostname=self.hostname, port=self.port, gss_auth=True)
+        self.ssh_client.connect(
+            hostname=self.hostname,
+            port=self.port,
+            gss_auth=True,
+            timeout=self.timeout,
+            banner_timeout=self.banner_timeout,
+            auth_timeout=self.auth_timeout,
+        )
 
     def exec_command(self, command):
         """Execute command and return exit code."""


### PR DESCRIPTION
closes https://github.com/reanahub/reana-job-controller/issues/206
closes https://github.com/reanahub/reana-job-controller/issues/345

How to test:
- mock that you have Slurm cluster locally:
  - add `slurmcern` [here](https://github.com/reanahub/reana/blob/master/helm/reana/values.yaml#L19) and redeploy the cluster
  - modify [this line](https://github.com/reanahub/reana-job-controller/blob/master/reana_job_controller/config.py#L50) to:
  ```python
  SUPPORTED_COMPUTE_BACKENDS = ["kubernetes", "slurmcern"]
  ```
  - place `wdb` breakpoint after setting the new configuration values [here](https://github.com/reanahub/reana-job-controller/pull/366/files#diff-cf7e1e5f5cc1e24ef851d65c6116c60cdfd9402ac75ce619a574f591b1b750f5R95)
  
- run some examples and set the new configurations as described in the [docs PR](https://github.com/reanahub/docs.reana.io/pull/124)
- inspect that the values are correctly passed through all the workflow engines

- other functionality needs to be tested on DEV using the real Slurm cluster