### PR TITLE
k8s-job-manager: disable k8s env variables in job's pod

### DIFF
--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -164,6 +164,7 @@ class KubernetesJobManager(JobManager):
                         "initContainers": [],
                         "volumes": [],
                         "restartPolicy": "Never",
+                        "enableServiceLinks": False,
                     },
                 },
             },


### PR DESCRIPTION
How to test:
1. Modify `reana-demo-helloworld`
```diff
--- a/reana.yaml
+++ b/reana.yaml
@@ -14,6 +14,7 @@ workflow:
     steps:
       - environment: 'python:2.7-slim'
         commands:
+          - env
           - python "${helloworld}"
               --inputfile "${inputfile}"
               --outputfile "${outputfile}"
```
2. Execute the modified `reana-demo-helloworld`
3. Check the steps logs

Expected result: k8s environment variables used for service discovery, such as `REANA_SERVER_SERVICE_HOST`, are not present in the environment of the jobs pods