### PR TITLE
config: vomsproxy sidecar upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.0 (UNRELEASED)
 --------------------------
 
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
+- Changes ``reana-auth-vomsproxy`` sidecar to latest version to support accessing ESCAPE VOMS.
 - Changes default Slurm partition to ``inf-short``.
 
 Version 0.8.1 (2022-02-07)

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -54,7 +54,7 @@ SUPPORTED_COMPUTE_BACKENDS = os.getenv(
 
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv(
-    "VOMSPROXY_CONTAINER_IMAGE", "reanahub/reana-auth-vomsproxy:1.0.0"
+    "VOMSPROXY_CONTAINER_IMAGE", "reanahub/reana-auth-vomsproxy:1.1.0"
 )
 """Default docker image of VOMSPROXY sidecar container."""
 


### PR DESCRIPTION
Upgrades to the latest reana-env-vomsproxy in order to have proper
ESCAPE VOMS support.