### PR TITLE
job manager: respect user-supplied VOMS proxy file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Version 0.9.0 (UNRELEASED)
 
 - Adds support for Rucio
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
-- Changes ``reana-auth-vomsproxy`` sidecar to latest version to support accessing ESCAPE VOMS.
+- Changes ``reana-auth-vomsproxy`` sidecar to the latest stable version to support client-side proxy file generation technique and ESCAPE VOMS.
 - Changes default Slurm partition to ``inf-short``.
 - Changes to PostgreSQL 12.10.
 

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -54,7 +54,7 @@ SUPPORTED_COMPUTE_BACKENDS = os.getenv(
 
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv(
-    "VOMSPROXY_CONTAINER_IMAGE", "reanahub/reana-auth-vomsproxy:1.1.0"
+    "VOMSPROXY_CONTAINER_IMAGE", "reanahub/reana-auth-vomsproxy:1.2.0"
 )
 """Default docker image of VOMSPROXY sidecar container."""
 


### PR DESCRIPTION
Allows respecting user-generated VOMS proxy file technique:

- If a user generates VOMS proxy file on the client side, and uploads it as a user secret in a file specified by VOMSPROXY_FILE, then this file is reused in the sidecar. This mode is suitable for multi-user REANA deployments where users wouldn't trust to upload their Grid certificate details as Kubernetes secret.

- Otherwise if VOMSPROXY_FILE does not exist, we fall back to generating the VOMS proxy file inside the sidecar, as before. This mode is suitable for single-user REANA deployments where the user doesn't hesitate to upload their Grid certificate details. For example, when running REANA backend on user's laptop for development purposes.

Improves the VOMS proxy and the Rucio sidecar error messages in case user doesn't set the required environment variable or file secrets.

Closes reanahub/reana-auth-vomsproxy#16.