### PR TITLE
slurmcern: fix HPC job submission issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.9.1 (UNRELEASED)
+--------------------------
+
+- Fixes intermittent Slurm connection issues by DNS-resolving the Slurm head node IPv4 address before establishing connections.
+- Changes Paramiko to version 3.0.0.
+
 Version 0.9.0 (2023-01-20)
 --------------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "reana"
-copyright = "2017-2020, info@reana.io"
+copyright = "2017-2023, info@reana.io"
 author = "info@reana.io"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-paramiko[gssapi]==2.7.1
+paramiko[gssapi]==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,8 @@ pyrsistent==0.19.3        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2022.7.1            # via bravado-core
 pyyaml==5.4.1             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.1  # via reana-db, reana-job-controller (setup.py)
-reana-db==0.9.1           # via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.9.2	# via reana-db, reana-job-controller (setup.py)
+reana-db==0.9.1	# via reana-job-controller (setup.py)
 requests-oauthlib==1.3.1  # via kubernetes
 requests==2.28.2          # via bravado, bravado-core, kubernetes, requests-oauthlib
 retrying==1.3.4           # via reana-job-controller (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ monotonic==1.6            # via bravado
 msgpack-python==0.5.6     # via bravado
 msgpack==1.0.4            # via bravado-core
 oauthlib==3.2.2           # via requests-oauthlib
-paramiko[gssapi]==2.7.1   # via -r requirements.in
+paramiko[gssapi]==3.0.0   # via -r requirements.in
 psycopg2-binary==2.9.5    # via reana-db
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via paramiko, pyasn1-modules, rsa

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "tests": tests_require,
-    "ssh": ["paramiko[gssapi]>=2.6.0"],
+    "ssh": ["paramiko[gssapi]>=3.0.0"],
 }
 
 # Python tests need SSH dependencies for imports

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     "Werkzeug>=2.1.0",
     "fs>=2.0",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes]>=0.9.1,<0.10.0",
+    "reana-commons[kubernetes]>=0.9.2,<0.10.0",
     "reana-db>=0.9.1,<0.10.0",
     "htcondor==8.9.11",
     "retrying>=1.3.3",


### PR DESCRIPTION
Fixes intermittent HPC job submission issues by DNS-resolving the Slurm head node IPv4 address before establishing the connection.

Closes #368.