### PR TITLE
k8s: use unique error messages

### DIFF
--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -170,7 +170,7 @@ class JobMonitorKubernetes(JobMonitor):
             self.job_manager_cls.stop(job_id)
             self.job_db[self.get_reana_job_id(job_id)]["deleted"] = True
         except client.rest.ApiException as e:
-            logging.error("Error while connecting to Kubernetes API: {}".format(e))
+            logging.error(f"Error from Kubernetes API while cleaning up job: {e}")
         except Exception as e:
             logging.error(traceback.format_exc())
             logging.error("Unexpected error: {}".format(e))
@@ -236,7 +236,7 @@ class JobMonitorKubernetes(JobMonitor):
 
             return pod_logs
         except client.rest.ApiException as e:
-            logging.error("Error while connecting to Kubernetes API: {}".format(e))
+            logging.error(f"Error from Kubernetes API while getting job logs: {e}")
             return None
         except Exception as e:
             logging.error(traceback.format_exc())
@@ -276,7 +276,7 @@ class JobMonitorKubernetes(JobMonitor):
         :param job_db: Dictionary which contains all current jobs.
         """
         while True:
-            logging.debug("Starting a new stream request to watch Jobs")
+            logging.info("Starting a new stream request to watch Jobs")
             try:
                 w = watch.Watch()
                 for event in w.stream(
@@ -300,7 +300,9 @@ class JobMonitorKubernetes(JobMonitor):
                         if JobStatus.should_cleanup_job(job_status):
                             self.clean_job(backend_job_id)
             except client.rest.ApiException as e:
-                logging.error("Error while connecting to Kubernetes API: {}".format(e))
+                logging.error(
+                    f"Error from Kubernetes API while watching jobs pods: {e}"
+                )
             except Exception as e:
                 logging.error(traceback.format_exc())
                 logging.error("Unexpected error: {}".format(e))

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -250,7 +250,9 @@ class KubernetesJobManager(JobManager):
             )
             return self.job["metadata"]["name"]
         except ApiException as e:
-            logging.error("Error while connecting to Kubernetes" " API: {}".format(e))
+            logging.error(
+                f"An error has occurred while connecting to Kubernetes API to submit a job: {e}"
+            )
         except Exception as e:
             logging.error(traceback.format_exc())
             logging.debug("Unexpected error: {}".format(e))
@@ -270,8 +272,7 @@ class KubernetesJobManager(JobManager):
             )
         except ApiException as e:
             logging.error(
-                "An error has occurred while connecting to Kubernetes API "
-                "Server \n {}".format(e)
+                f"An error has occurred while connecting to Kubernetes API to stop a job: {e}"
             )
             raise ComputingBackendSubmissionError(e.reason)
 


### PR DESCRIPTION
This commit changes the error messages used to log k8s API errors so
that each of them is unique. This will help to debug #383.
