### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,9 +2,15 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "80...100"
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        base: auto
+        target: auto
+        threshold: 2%
 
 parsers:
   gcov:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Use Ubuntu LTS base image
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # Use default answers in installation commands
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -195,7 +195,7 @@
                       "atlas.cern.ch",
                       "atlas-condb.cern.ch"
                     ],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -207,7 +207,7 @@
                       "atlas.cern.ch",
                       "atlas-condb.cern.ch"
                     ],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -300,7 +300,7 @@
                     "atlas.cern.ch",
                     "atlas-condb.cern.ch"
                   ],
-                  "docker_img": "busybox",
+                  "docker_img": "docker.io/library/busybox",
                   "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
                   "max_restart_count": 3,
                   "restart_count": 0,

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -54,7 +54,7 @@ SUPPORTED_COMPUTE_BACKENDS = os.getenv(
 
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv(
-    "VOMSPROXY_CONTAINER_IMAGE", "reanahub/reana-auth-vomsproxy:1.2.0"
+    "VOMSPROXY_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-vomsproxy:1.2.0"
 )
 """Default docker image of VOMSPROXY sidecar container."""
 
@@ -70,7 +70,7 @@ VOMSPROXY_CERT_CACHE_FILENAME = "x509up_proxy"
 """Name of the voms-proxy certificate cache file."""
 
 RUCIO_CONTAINER_IMAGE = os.getenv(
-    "RUCIO_CONTAINER_IMAGE", "reanahub/reana-auth-rucio:1.0.0"
+    "RUCIO_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-rucio:1.0.0"
 )
 """Default docker image of RUCIO sidecar container."""
 

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -135,7 +135,7 @@ def get_jobs():  # noqa
                   "1612a779-f3fa-4344-8819-3d12fa9b9d90": {
                     "cmd": "date",
                     "cvmfs_mounts": ['atlas.cern.ch', 'atlas-condb.cern.ch'],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "1612a779-f3fa-4344-8819-3d12fa9b9d90",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -144,7 +144,7 @@ def get_jobs():  # noqa
                   "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20": {
                     "cmd": "date",
                     "cvmfs_mounts": ['atlas.cern.ch', 'atlas-condb.cern.ch'],
-                    "docker_img": "busybox",
+                    "docker_img": "docker.io/library/busybox",
                     "job_id": "2e4bbc1d-db5e-4ee0-9701-6e2b1ba55c20",
                     "max_restart_count": 3,
                     "restart_count": 0,
@@ -289,7 +289,7 @@ def get_job(job_id):  # noqa
               "job": {
                 "cmd": "date",
                 "cvmfs_mounts": ['atlas.cern.ch', 'atlas-condb.cern.ch'],
-                "docker_img": "busybox",
+                "docker_img": "docker.io/library/busybox",
                 "job_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
                 "max_restart_count": 3,
                 "restart_count": 0,

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,7 @@ set -o errexit
 set -o nounset
 
 COMPONENT_NAME=reana-job-controller
-DOCKER_IMAGE_NAME=reanahub/$COMPONENT_NAME
+DOCKER_IMAGE_NAME=docker.io/reanahub/$COMPONENT_NAME
 PLATFORM="$(python -c 'import platform; print(platform.system())')"
 
 # Verify that db container is running before continuing
@@ -45,7 +45,7 @@ clean_old_db_container () {
 
 start_db_container () {
     echo '==> [INFO] Starting DB container...'
-    docker run --rm --name postgres__reana-job-controller -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d postgres:12.13
+    docker run --rm --name postgres__reana-job-controller -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d docker.io/library/postgres:12.13
     _check_ready "Postgres" _db_check
     db_container_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' postgres__reana-job-controller)
     export REANA_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:mysecretpassword@$db_container_ip/postgres
@@ -94,7 +94,7 @@ check_pytest () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 }
 
 check_docker_build () {

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,7 +38,7 @@ def test_execute_kubernetes_job(
     env_var_key = "key"
     env_var_value = "value"
     expected_env_var = {env_var_key: env_var_value}
-    expected_image = "busybox"
+    expected_image = "docker.io/library/busybox"
     expected_command = "ls"
     monkeypatch.setenv("REANA_USER_ID", str(default_user.id_))
     job_manager = KubernetesJobManager(
@@ -108,7 +108,7 @@ def test_stop_kubernetes_job(
     workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
     expected_env_var_name = "env_var"
     expected_env_var_value = "value"
-    expected_image = "busybox"
+    expected_image = "docker.io/library/busybox"
     expected_command = ["ls"]
     monkeypatch.setenv("REANA_USER_ID", str(default_user.id_))
     job_manager = KubernetesJobManager(
@@ -151,6 +151,6 @@ def test_execution_hooks():
         def cache_job(self):
             self.order_list.append(4)
 
-    job_manager = TestJobManger("busybox", "ls", {})
+    job_manager = TestJobManger("docker.io/library/busybox", "ls", {})
     job_manager.execute()
     assert job_manager.order_list == [1, 2, 3, 4]


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.