### PR TITLE
job-monitor: fix deletion of failed jobs with sidecar containers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.1 (UNRELEASED)
 --------------------------
 
 - Fixes intermittent Slurm connection issues by DNS-resolving the Slurm head node IPv4 address before establishing connections.
+- Fixes deletion of failed jobs not being performed when Kerberos is enabled.
 - Changes Paramiko to version 3.0.0.
 - Changes HTCondor to version 9.0.17 (LTS).
 

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -179,27 +179,27 @@ class JobMonitorKubernetes(JobMonitor):
             status = JobStatus.failed.name
         elif job_pod.status.phase == "Pending":
             container_statuses = self._get_job_container_statuses(job_pod)
-            try:
-                for container in container_statuses:
+            for container in container_statuses:
+                try:
                     reason = container.state.waiting.reason
-                    if "ErrImagePull" in reason:
-                        logging.info(
-                            "Container {} in Kubernetes job {} "
-                            "failed to fetch image.".format(
-                                container.name, backend_job_id
-                            )
-                        )
-                        status = JobStatus.failed.name
-                    elif "InvalidImageName" in reason:
-                        logging.info(
-                            "Container {} in Kubernetes job {} "
-                            "failed due to invalid image name.".format(
-                                container.name, backend_job_id
-                            )
-                        )
-                        status = JobStatus.failed.name
-            except (AttributeError, TypeError):
-                pass
+                except AttributeError:
+                    reason = None
+
+                if not reason:
+                    continue
+
+                if "ErrImagePull" in reason:
+                    logging.info(
+                        f"Container {container.name} in Kubernetes job {backend_job_id} "
+                        "failed to fetch image."
+                    )
+                    status = JobStatus.failed.name
+                elif "InvalidImageName" in reason:
+                    logging.info(
+                        f"Container {container.name} in Kubernetes job {backend_job_id} "
+                        "failed due to invalid image name."
+                    )
+                    status = JobStatus.failed.name
 
         return status
 

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -71,6 +71,7 @@ def test_kubernetes_get_job_logs(
         ("Pending", "InvalidImageName", "failed"),
         ("Succeeded", "Completed", "finished"),
         ("Failed", "Error", "failed"),
+        ("Pending", ["Running", "ErrImagePull"], "failed"),
     ],
 )
 def test_kubernetes_get_job_status(


### PR DESCRIPTION
**job-monitor: fix deletion of failed jobs with sidecar containers**

Fix an issue where job pods were not deleted when sidecar containers
were used (e.g. to renew Kerberos tickets).
  
Before, updating the status of a job was not performed unless all the
containers were terminated. This does not work if only one container
fails to start (e.g. if failing to pull a docker image), while the
sidecar container keeps running.
  
Closes #391

**job-monitor: check all container statuses of pending pod**

Make sure that the statuses of all containers are checked when a pod is
in the `Pending` phase. Before, the checks were stopping at the first
non-waiting container, thus potentially not considering containers that
were waiting due to `ImagePullErr` or `InvalidImageName`.

**How to test**
Check that workflows are cleaned up correctly and that logs are fetched in various scenarios:
  - Kerberos is enabled/disabled
  - Job fails while pulling image (with/without Kerberos)
  - Job fails because of job timeout (see https://github.com/reanahub/reana-job-controller/pull/350#discussion_r783011488)