### PR TITLE
global: update to apispec v3

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -124,7 +124,6 @@
     "title": "reana-job-controller",
     "version": "0.9.1a2"
   },
-  "parameters": {},
   "paths": {
     "/apispec": {},
     "/job_cache": {
@@ -413,6 +412,5 @@
       }
     }
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -36,7 +36,9 @@ class JobRequest(Schema):
     job_name = fields.Str(required=True)
     workflow_workspace = fields.Str(required=True)
     workflow_uuid = fields.Str(required=True)
-    cmd = fields.Function(missing="", deserialize=deserialise_job_command)
+    cmd = fields.Function(
+        missing="", deserialize=deserialise_job_command, type="string"
+    )
     prettified_cmd = fields.Str(missing="")
     docker_img = fields.Str(required=True)
     cvmfs_mounts = fields.String(missing="")

--- a/reana_job_controller/spec.py
+++ b/reana_job_controller/spec.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +10,8 @@
 """OpenAPI generator."""
 
 from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
 from flask import current_app
 
 from reana_job_controller.schemas import Job, JobRequest
@@ -21,20 +23,18 @@ def build_openapi_spec():
     spec = APISpec(
         title="reana-job-controller",
         version=__version__,
+        openapi_version="2.0",
         info=dict(description="REANA Job Controller API"),
-        plugins=[
-            "apispec.ext.flask",
-            "apispec.ext.marshmallow",
-        ],
+        plugins=[FlaskPlugin(), MarshmallowPlugin()],
     )
 
     # Add marshmallow models to specification
-    spec.definition("Job", schema=Job)
-    spec.definition("JobRequest", schema=JobRequest)
+    spec.components.schema("Job", schema=Job)
+    spec.components.schema("JobRequest", schema=JobRequest)
 
     # Collect OpenAPI docstrings from Flask endpoints
     for key in current_app.view_functions:
         if key != "static" and key != "get_openapi_spec":
-            spec.add_path(view=current_app.view_functions[key])
+            spec.path(view=current_app.view_functions[key])
 
     return spec.to_dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@
 #
 alembic==1.10.1           # via reana-db
 amqp==5.1.1               # via kombu
-apispec==0.39.0           # via reana-job-controller (setup.py)
+apispec-webframeworks==0.5.2  # via reana-job-controller (setup.py)
+apispec[yaml]==3.3.2      # via apispec-webframeworks, reana-job-controller (setup.py)
 appdirs==1.4.4            # via fs
 attrs==22.2.0             # via jsonschema
 bcrypt==4.0.1             # via paramiko
@@ -54,8 +55,8 @@ pyrsistent==0.19.3        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2022.7.1            # via bravado-core
 pyyaml==5.4.1             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.3a3	# via reana-db, reana-job-controller (setup.py)
-reana-db==0.9.1	# via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.9.3a4  # via reana-db, reana-job-controller (setup.py)
+reana-db==0.9.1           # via reana-job-controller (setup.py)
 requests-oauthlib==1.3.1  # via kubernetes
 requests==2.28.2          # via bravado, bravado-core, kubernetes, requests-oauthlib
 retrying==1.3.4           # via reana-job-controller (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.9.0a7,<0.10.0",
+    "pytest-reana>=0.9.1a1,<0.10.0",
 ]
 
 extras_require = {
@@ -53,13 +53,15 @@ setup_requires = [
 ]
 
 install_requires = [
-    "apispec>=0.21.0,<0.40",
+    # apispec>=4.0 drops support for marshmallow<3
+    "apispec[yaml]>=3.0,<4.0",
+    "apispec-webframeworks",
     "Flask>=2.1.1,<2.2.0",
     "jinja2<3.1.0",
     "Werkzeug>=2.1.0",
     "fs>=2.0",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes]>=0.9.3a3,<0.10.0",
+    "reana-commons[kubernetes]>=0.9.3a4,<0.10.0",
     "reana-db>=0.9.1,<0.10.0",
     "htcondor==9.0.17",
     "retrying>=1.3.3",


### PR DESCRIPTION
Update to apispec v3, as the version used before is not compatible with
PyYAML v6.

Closes reanahub/reana-commons#399
