### PR TITLE
job-monitor: consider `OOMKilled` pods as failed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.9.1 (UNRELEASED)
 
 - Fixes intermittent Slurm connection issues by DNS-resolving the Slurm head node IPv4 address before establishing connections.
 - Fixes deletion of failed jobs not being performed when Kerberos is enabled.
+- Fixes job monitoring to consider OOM-killed jobs as failed.
 - Changes Paramiko to version 3.0.0.
 - Changes HTCondor to version 9.0.17 (LTS).
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -48,6 +48,10 @@ start_db_container () {
     docker run --rm --name postgres__reana-job-controller -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d docker.io/library/postgres:12.13
     _check_ready "Postgres" _db_check
     db_container_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' postgres__reana-job-controller)
+    if [[ -z $db_container_ip ]]; then
+        # container does not have an IP when using podman
+        db_container_ip="localhost"
+    fi
     export REANA_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:mysecretpassword@$db_container_ip/postgres
 }
 

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -72,6 +72,7 @@ def test_kubernetes_get_job_logs(
         ("Succeeded", "Completed", "finished"),
         ("Failed", "Error", "failed"),
         ("Pending", ["Running", "ErrImagePull"], "failed"),
+        ("Succeeded", "OOMKilled", "failed"),
     ],
 )
 def test_kubernetes_get_job_status(


### PR DESCRIPTION
- job-monitor: consider `OOMKilled` pods as failed
- tests: add support for podman

Closes #396

Note that this PR depends on #393 