### PR TITLE
docker: fix location of htcondorcern build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN if echo "$COMPUTE_BACKENDS" | grep -q "htcondorcern"; then \
       set -e; \
       apt-get update -y; \
       apt-get install --no-install-recommends -y wget alien gnupg2 rand; \
-      wget -O ngbauth-submit.rpm https://linuxsoft.cern.ch/internal/repos/batch8s-stable/x86_64/os/Packages/ngbauth-submit-0.26-2.el8s.noarch.rpm; \
-      wget -O myschedd.rpm https://linuxsoft.cern.ch/internal/repos/batch8s-stable/x86_64/os/Packages/myschedd-1.9-2.el8s.x86_64.rpm; \
+      wget -O ngbauth-submit.rpm https://linuxsoft.cern.ch/internal/repos/batch8s-stable/x86_64/os/Packages/n/ngbauth-submit-0.26-2.el8s.noarch.rpm; \
+      wget -O myschedd.rpm https://linuxsoft.cern.ch/internal/repos/batch8s-stable/x86_64/os/Packages/m/myschedd-1.9-2.el8s.x86_64.rpm; \
       yes | alien -i myschedd.rpm; \
       yes | alien -i ngbauth-submit.rpm; \
       rm -rf myschedd.rpm ngbauth-submit.rpm; \

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -154,7 +154,7 @@ class SlurmJobManagerCERN(JobManager):
     def _get_container(self):
         """Get container image."""
         if self.img_type_docker:
-            return self.docker_img.split("/", 1)[-1].replace(":", "_") + ".sif"
+            return self.docker_img.split("/")[-1].replace(":", "_") + ".sif"
         return self.docker_img
 
     def _dump_job_submission_file(self):


### PR DESCRIPTION
Fixes location of htcondorcern build dependencies that changed recently in the CERN Linux batch repositories. Closes #403.