### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022 CERN.
+# Copyright (C) 2020, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -122,7 +122,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install system dependencies
-        run: sudo apt-get install libkrb5-dev
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install libkrb5-dev
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -93,6 +93,7 @@ check_sphinx () {
 check_pytest () {
     clean_old_db_container
     start_db_container
+    trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
     python setup.py test
     stop_db_container
 }

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     "apispec-webframeworks",
     "Flask>=2.1.1,<2.2.0",
     "jinja2<3.1.0",
-    "Werkzeug>=2.1.0",
+    "Werkzeug>=2.1.0,<3.0",
     "fs>=2.0",
     "marshmallow>2.13.0,<=2.20.1",
     "reana-commons[kubernetes]>=0.9.3,<0.10.0",


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTARG environment variable. Example: `PYTESTARG=test_version ./run-tests.sh --check-pytest`.

Cleans up running DB container when some pytest segfaults.

Pins werkzeug upper version due to incompatibilities with Flask version after recent releases.

Closes reanahub/reana#755.