### PR TITLE
feat(shutdown): stop all running jobs before stopping workflow (#423)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -410,6 +410,53 @@
         },
         "summary": "Returns the logs for a given job."
       }
+    },
+    "/shutdown": {
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "All running jobs will be stopped and no more jobs will be scheduled. Kubernetes will call this endpoint before stopping the pod (PreStop hook).",
+        "operationId": "shutdown",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. All jobs were stopped.",
+            "examples": {
+              "application/json": {
+                "message": "All jobs stopped."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Something went wrong while stopping the jobs.",
+            "examples": {
+              "application/json": {
+                "message": "Could not stop jobs cdcf48b1-c2f3-4693-8230-b066e088444c"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Stop reana-job-controller"
+      }
     }
   },
   "swagger": "2.0"

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -294,8 +294,19 @@ class HTCondorJobManagerCERN(JobManager):
         logging.info("Spooling jobs {} output.".format(backend_job_id))
         schedd.retrieve("ClusterId == {}".format(backend_job_id))
 
-    def get_logs(backend_job_id, workspace):
-        """Return job logs if log files are present."""
+    @classmethod
+    def get_logs(cls, backend_job_id, **kwargs):
+        """Return job logs if log files are present.
+
+        :param backend_job_id: ID of the job in the backend.
+        :param kwargs: Additional parameters needed to fetch logs.
+            In the case of HTCondor, the ``workspace`` parameter is needed.
+        :return: String containing the job logs.
+        """
+        if "workspace" not in kwargs:
+            raise ValueError("Missing 'workspace' parameter")
+        workspace = kwargs["workspace"]
+
         stderr_file = os.path.join(
             workspace, "reana_job." + str(backend_job_id) + ".0.err"
         )

--- a/reana_job_controller/job_db.py
+++ b/reana_job_controller/job_db.py
@@ -8,9 +8,10 @@
 
 """REANA-Job-Controller job database."""
 
+import logging
 from reana_commons.utils import calculate_hash_of_dir, calculate_job_input_hash
 from reana_db.database import Session
-from reana_db.models import JobCache
+from reana_db.models import Job, JobCache
 
 JOB_DB = {}
 
@@ -111,3 +112,32 @@ def retrieve_job_logs(job_id):
     :returns: Job's logs.
     """
     return JOB_DB[job_id].get("log")
+
+
+def store_job_logs(job_id, logs):
+    """Store job logs.
+
+    :param job_id: Internal REANA job ID.
+    :param logs: Job logs.
+    :type job_id: str
+    :type logs: str
+    """
+    logging.info(f"Storing job logs: {job_id}")
+    JOB_DB[job_id]["log"] = logs
+    try:
+        Session.query(Job).filter_by(id_=job_id).update(dict(logs=logs))
+        Session.commit()
+    except Exception as e:
+        logging.exception(f"Exception while saving logs: {e}")
+
+
+def update_job_status(job_id, status):
+    """Update job status.
+
+    :param job_id: Internal REANA job ID.
+    :param status: One of the possible status for jobs in REANA
+    :type job_id: str
+    :type status: str
+    """
+    logging.info(f"Updating status of job {job_id} to {status}")
+    JOB_DB[job_id]["status"] = status

--- a/reana_job_controller/job_db.py
+++ b/reana_job_controller/job_db.py
@@ -11,7 +11,7 @@
 import logging
 from reana_commons.utils import calculate_hash_of_dir, calculate_job_input_hash
 from reana_db.database import Session
-from reana_db.models import Job, JobCache
+from reana_db.models import Job, JobCache, JobStatus
 
 JOB_DB = {}
 
@@ -141,3 +141,9 @@ def update_job_status(job_id, status):
     """
     logging.info(f"Updating status of job {job_id} to {status}")
     JOB_DB[job_id]["status"] = status
+    try:
+        job_in_db = Session.query(Job).filter_by(id_=job_id).one()
+        job_in_db.status = JobStatus[status]
+        Session.commit()
+    except Exception as e:
+        logging.exception(f"Exception while updating status: {e}")

--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -109,7 +109,7 @@ class JobManager:
         job_db_entry = JobTable(
             backend_job_id=backend_job_id,
             workflow_uuid=self.workflow_uuid,
-            status=JobStatus.created.name,
+            status=JobStatus.created,
             compute_backend=self.compute_backend,
             cvmfs_mounts=self.cvmfs_mounts or "",
             shared_file_system=self.shared_file_system or False,

--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -92,11 +92,14 @@ class JobManager:
         """
         raise NotImplementedError
 
-    def get_logs(self):
-        """Get job log.
+    @classmethod
+    def get_logs(cls, backend_job_id, **kwargs):
+        """Return job logs if log files are present.
 
-        :returns: stderr, stdout of a job.
-        :rtype: dict
+        :param backend_job_id: ID of the job in the backend.
+        :param kwargs: Additional parameters needed to fetch logs.
+            These depend on the chosen compute backend.
+        :return: String containing the job logs.
         """
         raise NotImplementedError
 

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -113,7 +113,11 @@ class JobMonitorKubernetes(JobMonitor):
             https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Pod.md)
         """
         remaining_jobs = self._get_remaining_jobs(
-            statuses_to_skip=[JobStatus.finished.name, JobStatus.failed.name]
+            statuses_to_skip=[
+                JobStatus.finished.name,
+                JobStatus.failed.name,
+                JobStatus.stopped.name,
+            ]
         )
         backend_job_id = self.get_backend_job_id(job_pod)
         is_job_in_remaining_jobs = backend_job_id in remaining_jobs
@@ -291,7 +295,7 @@ class JobMonitorHTCondorCERN(JobMonitor):
         :param job_db: Dictionary which contains all current jobs.
         """
         ignore_hold_codes = [35, 16]
-        statuses_to_skip = ["finished", "failed"]
+        statuses_to_skip = ["finished", "failed", "stopped"]
         while True:
             try:
                 logging.info("Starting a new stream request to watch Condor Jobs")
@@ -422,7 +426,7 @@ class JobMonitorSlurmCERN(JobMonitor):
             banner_timeout=SLURM_SSH_BANNER_TIMEOUT,
             auth_timeout=SLURM_SSH_AUTH_TIMEOUT,
         )
-        statuses_to_skip = ["finished", "failed"]
+        statuses_to_skip = ["finished", "failed", "stopped"]
         while True:
             logging.debug("Starting a new stream request to watch Jobs")
             try:

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -172,6 +172,8 @@ class KubernetesJobManager(JobManager):
                         "initContainers": [],
                         "volumes": [],
                         "restartPolicy": "Never",
+                        # No need to wait a long time for jobs to gracefully terminate
+                        "terminationGracePeriodSeconds": 5,
                         "enableServiceLinks": False,
                     },
                 },

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -34,7 +34,10 @@ from reana_commons.job_utils import (
     validate_kubernetes_memory,
     kubernetes_memory_to_bytes,
 )
-from reana_commons.k8s.api_client import current_k8s_batchv1_api_client
+from reana_commons.k8s.api_client import (
+    current_k8s_batchv1_api_client,
+    current_k8s_corev1_api_client,
+)
 from reana_commons.k8s.kerberos import get_kerberos_k8s_config
 from reana_commons.k8s.secrets import REANAUserSecretsStore
 from reana_commons.k8s.volumes import (
@@ -242,6 +245,99 @@ class KubernetesJobManager(JobManager):
         except Exception:
             logging.exception("Unexpected error while submitting a job")
             raise
+
+    @classmethod
+    def _get_containers_logs(cls, job_pod) -> Optional[str]:
+        """Fetch the logs from all the containers in the given pod.
+
+        :param job_pod: Pod resource coming from Kubernetes.
+        """
+        try:
+            pod_logs = ""
+            container_statuses = (job_pod.status.container_statuses or []) + (
+                job_pod.status.init_container_statuses or []
+            )
+
+            logging.info(f"Grabbing pod {job_pod.metadata.name} logs ...")
+            for container in container_statuses:
+                # If we are here, it means that either all the containers have finished
+                # running or there has been some sort of failure. For this reason we get
+                # the logs of all containers, even if they are still running, as the job
+                # will not continue running after this anyway.
+                if container.state.terminated or container.state.running:
+                    container_log = (
+                        current_k8s_corev1_api_client.read_namespaced_pod_log(
+                            namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
+                            name=job_pod.metadata.name,
+                            container=container.name,
+                        )
+                    )
+                    pod_logs += "{}: :\n {}\n".format(container.name, container_log)
+                    if hasattr(container.state.terminated, "reason"):
+                        pod_logs += "\n{}\n".format(container.state.terminated.reason)
+                elif container.state.waiting:
+                    # No need to fetch logs, as the container has not started yet.
+                    pod_logs += "Container {} failed, error: {}".format(
+                        container.name, container.state.waiting.message
+                    )
+
+            return pod_logs
+        except client.rest.ApiException as e:
+            logging.error(f"Error from Kubernetes API while getting job logs: {e}")
+            return None
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            logging.error("Unexpected error: {}".format(e))
+            return None
+
+    @classmethod
+    def get_logs(cls, backend_job_id, **kwargs):
+        """Return job logs.
+
+        :param backend_job_id: ID of the job in the backend.
+        :param kwargs: Additional parameters needed to fetch logs.
+            In the case of Kubernetes, the ``job_pod`` parameter can be specified
+            to avoid fetching the pod specification from Kubernetes.
+        :return: String containing the job logs.
+        """
+        if "job_pod" in kwargs:
+            job_pod = kwargs["job_pod"]
+            assert (
+                job_pod.metadata.labels["job-name"] == backend_job_id
+            ), "Pod does not refer to correct job."
+        else:
+            job_pods = current_k8s_corev1_api_client.list_namespaced_pod(
+                namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
+                label_selector=f"job-name={backend_job_id}",
+            )
+            if not job_pods.items:
+                logging.error(f"Could not find any pod for job {backend_job_id}")
+                return None
+            job_pod = job_pods.items[0]
+
+        logs = cls._get_containers_logs(job_pod)
+
+        if job_pod.status.reason == "DeadlineExceeded":
+            if not logs:
+                logs = ""
+
+            message = f"\n{job_pod.status.reason}\nThe job was killed due to exceeding timeout"
+
+            try:
+                specified_timeout = job_pod.spec.active_deadline_seconds
+                message += f" of {specified_timeout} seconds."
+            except AttributeError:
+                message += "."
+                logging.error(
+                    f"Kubernetes job id: {backend_job_id}. Could not get job timeout from Job spec."
+                )
+
+            logs += message
+            logging.info(
+                f"Kubernetes job id: {backend_job_id} was killed due to timeout."
+            )
+
+        return logs
 
     def stop(backend_job_id, asynchronous=True):
         """Stop Kubernetes job execution.

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -248,6 +248,10 @@ def create_job():  # noqa
         job["backend_job_id"] = backend_jod_id
         job["compute_backend"] = compute_backend
         JOB_DB[str(job["job_id"])] = job
+        # FIXME: we do not detect whether the job has started running or not,
+        # so let's assume the job is running, even though it might be queued in
+        # the backend system
+        update_job_status(job_obj.job_id, JobStatus.running.name)
         job_monitor_cls = current_app.config["JOB_MONITORS"][compute_backend]()
         job_monitor_cls(
             app=current_app._get_current_object(),

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -11,6 +11,7 @@
 import copy
 import json
 import logging
+import threading
 
 from flask import Blueprint, current_app, jsonify, request
 from sqlalchemy.exc import OperationalError
@@ -18,6 +19,9 @@ from reana_commons.errors import (
     REANAKubernetesMemoryLimitExceeded,
     REANAKubernetesWrongMemoryFormat,
 )
+
+from reana_db.models import JobStatus
+
 
 from reana_job_controller.errors import ComputingBackendSubmissionError
 from reana_job_controller.job_db import (
@@ -28,14 +32,60 @@ from reana_job_controller.job_db import (
     retrieve_backend_job_id,
     retrieve_job,
     retrieve_job_logs,
+    store_job_logs,
+    update_job_status,
 )
 from reana_job_controller.schemas import Job, JobRequest
 from reana_job_controller.utils import update_workflow_logs
+from reana_job_controller import config
+
 
 blueprint = Blueprint("jobs", __name__)
 
 job_request_schema = JobRequest()
 job_schema = Job()
+
+
+class JobCreationCondition:
+    """Mechanism used to synchronize the creation of jobs.
+
+    This is used to make sure no thread is able to create new jobs during or after
+    the shutdown procedure, as otherwise some jobs might not be correctly stopped and
+    cleaned up. Jobs can still be created in parallel. This works similarly to a RW-lock.
+    """
+
+    def __init__(self):
+        """Initialise a new JobCreationCondition."""
+        self.condition = threading.Condition()
+        self.creation_permitted = True
+        self.ongoing_creations = 0
+        """Keep track of the number of ongoing job creations"""
+
+    def start_creation(self) -> bool:
+        """Check if a new job can be created."""
+        with self.condition:
+            if not self.creation_permitted:
+                return False
+            self.ongoing_creations += 1
+        return True
+
+    def stop_creation(self):
+        """Notify that the creation of the job has finished."""
+        with self.condition:
+            self.ongoing_creations -= 1
+            if self.ongoing_creations == 0:
+                self.condition.notify_all()
+
+    def disable_creation(self):
+        """Do not permit to create any new jobs."""
+        with self.condition:
+            # wait untill all job creations are finished
+            while self.ongoing_creations != 0:
+                self.condition.wait()
+            self.creation_permitted = False
+
+
+job_creation_condition = JobCreationCondition()
 
 
 @blueprint.route("/job_cache", methods=["GET"])
@@ -227,6 +277,10 @@ def create_job():  # noqa
             return jsonify({"message": e.message}), 403
         except REANAKubernetesWrongMemoryFormat as e:
             return jsonify({"message": e.message}), 400
+
+    if not job_creation_condition.start_creation():
+        return jsonify({"message": "Cannot create new jobs, shutting down"}), 400
+
     try:
         backend_jod_id = job_obj.execute()
     except OperationalError as e:
@@ -237,6 +291,9 @@ def create_job():  # noqa
         msg = f"Job submission failed. \n{e}"
         logging.error(msg, exc_info=True)
         return jsonify({"message": msg}), 500
+    finally:
+        job_creation_condition.stop_creation()
+
     if job_obj:
         job = copy.deepcopy(job_request)
         job["status"] = "started"
@@ -417,6 +474,89 @@ def delete_job(job_id):  # noqa
             )
     else:
         return jsonify({"message": "The job {} doesn't exist".format(job_id)}), 404
+
+
+@blueprint.route("/shutdown", methods=["GET"])
+def shutdown():
+    r"""Stop reana-job-controller.
+
+    All running jobs will be stopped and no more jobs will be scheduled.
+    Kubernetes will call this endpoint before stopping the pod (PreStop hook).
+    ---
+    delete:
+      summary: Stop reana-job-controller
+      description: >-
+        All running jobs will be stopped and no more jobs will be scheduled.
+        Kubernetes will call this endpoint before stopping the pod (PreStop hook).
+      operationId: shutdown
+      consumes:
+       - application/json
+      produces:
+       - application/json
+      responses:
+        200:
+          description: >-
+            Request successful. All jobs were stopped.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+                {"message": "All jobs stopped."}
+        500:
+          description: >-
+            Request failed. Something went wrong while stopping the jobs.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+                {"message": "Could not stop jobs cdcf48b1-c2f3-4693-8230-b066e088444c"}
+    """
+    logging.info("Starting shutdown")
+    job_creation_condition.disable_creation()
+
+    # Now no more jobs can be scheduled, let's stop all of the others.
+
+    jobs = retrieve_all_jobs()
+    failed_to_stop = []
+
+    # jobs is a list of dicts, where each dict has a single entry.
+    # the key of the dict is the job ID, the value contains the job details.
+    for job_dict in jobs:
+        for job_id, job in job_dict.items():
+            if job["status"] in ("finished", "failed", "stopped"):
+                continue
+
+            backend_job_id = retrieve_backend_job_id(job_id)
+            # FIXME: ideally we would not be accessing the database manually here
+            # to get the compute backend and the workspace, but this can wait for a general
+            # refactor of the "in-memory" database
+            compute_backend = JOB_DB[job_id]["compute_backend"]
+            workspace = JOB_DB[job_id]["obj"].workflow_workspace
+            job_manager_cls = config.COMPUTE_BACKENDS[compute_backend]()
+            logging.info(f"Stopping job {job_id} ({backend_job_id})")
+            try:
+                logs = job_manager_cls.get_logs(backend_job_id, workspace=workspace)
+                store_job_logs(job_id, logs)
+                job_manager_cls.stop(backend_job_id)
+                update_job_status(job_id, JobStatus.stopped.name)
+                # FIXME: ideally also here we would not access the database directly
+                JOB_DB[job_id]["deleted"] = True
+            except Exception:
+                logging.exception(f"Could not stop job {job_id} ({backend_job_id})")
+                failed_to_stop.append((job_id))
+
+    if failed_to_stop:
+        return (
+            jsonify({"message": "Could not stop jobs " + ", ".join(failed_to_stop)}),
+            500,
+        )
+    return jsonify({"message": "All jobs stopped."}), 200
 
 
 @blueprint.route("/apispec", methods=["GET"])

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -236,8 +236,19 @@ class SlurmJobManagerCERN(JobManager):
             else:
                 sftp.get(remote_path, local_path)
 
-    def get_logs(backend_job_id, workspace):
-        """Return job logs if log files are present."""
+    @classmethod
+    def get_logs(cls, backend_job_id, **kwargs):
+        """Return job logs if log files are present.
+
+        :param backend_job_id: ID of the job in the backend.
+        :param kwargs: Additional parameters needed to fetch logs.
+            In the case of Slurm, the ``workspace`` parameter is needed.
+        :return: String containing the job logs.
+        """
+        if "workspace" not in kwargs:
+            raise ValueError("Missing 'workspace' parameter")
+        workspace = kwargs["workspace"]
+
         stderr_file = os.path.join(
             workspace, "reana_job." + str(backend_job_id) + ".err"
         )

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -40,31 +40,6 @@ def test_initialisation(app):
 
 
 @pytest.mark.parametrize(
-    "k8s_phase,k8s_container_state,k8s_logs,pod_logs",
-    [
-        ("Pending", "ErrImagePull", "pull access denied", None),
-        ("Pending", "InvalidImageName", "couldn't parse image", None),
-        ("Succeeded", "Completed", None, "job finished"),
-        ("Failed", "Error", None, "job failed"),
-    ],
-)
-def test_kubernetes_get_job_logs(
-    k8s_phase, k8s_container_state, k8s_logs, pod_logs, app, kubernetes_job_pod
-):
-    """Test retrieval of job logs."""
-    k8s_corev1_api_client = mock.MagicMock()
-    k8s_corev1_api_client.read_namespaced_pod_log = lambda **kwargs: pod_logs
-    with mock.patch.multiple(
-        "reana_job_controller.job_monitor",
-        current_k8s_corev1_api_client=k8s_corev1_api_client,
-        threading=mock.DEFAULT,
-    ):
-        job_monitor_k8s = JobMonitorKubernetes(app=app)
-        job_pod = kubernetes_job_pod(k8s_phase, k8s_container_state)
-        assert (k8s_logs or pod_logs) in job_monitor_k8s.get_job_logs(job_pod)
-
-
-@pytest.mark.parametrize(
     "k8s_phase,k8s_container_state,expected_reana_status",
     [
         ("Pending", "ErrImagePull", "failed"),


### PR DESCRIPTION
- refactor(job-monitor): centralise logs and status updates (#423)
- refactor(job-db): set job status also in the main database (#423)
- refactor(job-monitor): move fetching of logs to job-manager (#423)
- feat(shutdown): stop all running jobs before stopping workflow (#423)


Closes https://github.com/reanahub/reana-workflow-controller/issues/546