### PR TITLE
fix(database): limit the number of open database connections (#437)

### DIFF
--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -11,9 +11,8 @@
 import json
 
 from reana_commons.utils import calculate_file_access_time
-from reana_db.database import Session, engine as db_engine
-from reana_db.models import Job as JobTable
-from reana_db.models import JobCache, JobStatus, Workflow
+from reana_db.database import Session
+from reana_db.models import Job as JobTable, JobCache, JobStatus, Workflow
 
 from reana_job_controller.config import CACHE_ENABLED
 
@@ -65,7 +64,6 @@ class JobManager:
             inst.create_job_in_db(backend_job_id)
             if CACHE_ENABLED:
                 inst.cache_job()
-            db_engine.dispose()
             return backend_job_id
 
         return wrapper


### PR DESCRIPTION
Up until now, to avoid keeping open idle connections with the database,
the connection pool was disposed after every request. However,
connections that are checked out at the moment of the pool disposal are
kept open, and they do not count towards the maximum number of
connections set by `SQLALCHEMY_POOL_SIZE` and `SQLALCHEMY_MAX_OVERFLOW`.

This resulted in many connections being open at the same time,
saturating the capacity of the database.

Instead of destroying the pool at each request, connections are closed
each time they are put back in the pool. The end result is the same, as
no idle connection is kept open for long periods of time. At the same
time, the pool enforces that the number of open connections is limited,
so that the database is not overwhelmed.
