### PR TITLE
fix(config): update reana-auth-vomsproxy to 1.2.1 to fix WLCG IAM

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -63,7 +63,7 @@ SUPPORTED_COMPUTE_BACKENDS = os.getenv(
 
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv(
-    "VOMSPROXY_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-vomsproxy:1.2.0"
+    "VOMSPROXY_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-vomsproxy:1.2.1"
 )
 """Default docker image of VOMSPROXY sidecar container."""
 


### PR DESCRIPTION
Update reana-auth-vomsproxy to the latest version in order to fix VOMS proxy initialisation troubles now that WLCG IAM is in production.