### PR TITLE
feat(job_monitor): log job pod errors, disruptions to warning (#468)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ The list of contributors in alphabetical order:
 - [Elena Gazzarrini](https://orcid.org/0000-0001-5772-5166)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Kenyi Hurtado-Anampa](https://orcid.org/0000-0002-9779-3566)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)
 - [Marco Vidal](https://orcid.org/0000-0002-9363-4971)

--- a/reana_job_controller/factory.py
+++ b/reana_job_controller/factory.py
@@ -18,6 +18,7 @@ from sqlalchemy import event
 
 from reana_job_controller import config
 from reana_job_controller.spec import build_openapi_spec
+from reana_job_controller.utils import MultilineFormatter
 
 
 @event.listens_for(db_engine, "checkin")
@@ -55,7 +56,12 @@ def shutdown_session(response_or_exc):
 
 def create_app(config_mapping=None):
     """Create REANA-Job-Controller application."""
-    logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
+    handler = logging.StreamHandler()
+    handler.setFormatter(MultilineFormatter(REANA_LOG_FORMAT))
+    logging.basicConfig(
+        level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT, handlers=[handler]
+    )
+
     app = Flask(__name__)
     app.secret_key = "mega secret key"
     app.session = Session

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,35 @@ import os
 import socket
 import subprocess
 import sys
+from logging import Formatter, LogRecord
 
 from reana_db.database import Session
 from reana_db.models import Workflow
+
+
+class MultilineFormatter(Formatter):
+    """Logging formatter for multiline logs."""
+
+    def format(self, record: LogRecord):
+        """Format multiline log message.
+
+        :param record: LogRecord object.
+        :type record: logging.LogRecord
+
+        :return: Formatted log message.
+        :rtype: str
+        """
+        save_msg = str(record.msg)
+        output = ""
+        lines = save_msg.splitlines()
+        for line in lines:
+            record.msg = line
+            output += super().format(record) + "\n"
+        output = output.strip()
+        record.msg = save_msg
+        record.message = output
+
+        return output
 
 
 def singleton(cls):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+import logging
+import pytest
+
+from reana_job_controller.utils import MultilineFormatter
+
+"""REANA-Job-Controller utils tests."""
+
+
+@pytest.mark.parametrize(
+    "message,expected_output",
+    [
+        (
+            "test",
+            "name | INFO | test",
+        ),
+        (
+            "test\n",
+            "name | INFO | test",
+        ),
+        (
+            "test\ntest",
+            "name | INFO | test\nname | INFO | test",
+        ),
+        (
+            "test\ntest\n\n\n",
+            "name | INFO | test\nname | INFO | test\nname | INFO | \nname | INFO |",
+        ),
+        (
+            "   test\ntest   ",
+            "name | INFO |    test\nname | INFO | test",
+        ),
+        (
+            "   t e s\tt\n     t e s t   ",
+            "name | INFO |    t e s\tt\nname | INFO |      t e s t",
+        ),
+    ],
+)
+def test_multiline_formatter_format(message, expected_output):
+    """Test MultilineFormatter formatting."""
+    formatter = MultilineFormatter("%(name)s | " "%(levelname)s | %(message)s")
+    assert (
+        formatter.format(
+            logging.LogRecord(
+                "name",
+                logging.INFO,
+                "pathname",
+                1,
+                message,
+                None,
+                None,
+            ),
+        )
+        == expected_output
+    )


### PR DESCRIPTION
Related to https://github.com/reanahub/reana/issues/824

Fix multiline formatting. Log pod errors, evictions and other problematic events to warning log. Cover new functionality with tests.

Example logs (with FluentBit configured to collect `job-controller` logs):

OOM killed:

```
2024-09-04 11:08:11,795 | root | MainThread | INFO | Publishing step:0, cmd: python "code/helloworld.py" --inputfile "data/names.txt" --outputfile "results/greetings.txt" --sleeptime 1, total steps 1 to MQ
2024-09-04 11:08:13,734 | root | kubernetes_job_monitor | WARNING | Job reana-run-job-ad805df8-6d8c-4b00-9942-25ca994af5ad-f62zc was terminated, reason: StartError, message: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: container init was OOM-killed (memory limit too low?): unknown
2024-09-04 11:08:17,805 | root | MainThread | INFO | Workflow 43250308-f42b-4506-bee8-556be0fbe754 finished. Files available at /var/reana/users/00000000-0000-0000-0000-000000000000/workflows/43250308-f42b-4506-bee8-556be0fbe754.
```

DeadlineExceeded:

```
2024-09-04 11:08:57,032 | root | MainThread | INFO | Publishing step:0, cmd: python "code/helloworld.py" --inputfile "data/names.txt" --outputfile "results/greetings.txt" --sleeptime 1, total steps 1 to MQ
2024-09-04 11:09:04,959 | root | kubernetes_job_monitor | WARNING | Job reana-run-job-9ee1aba5-73fd-4ac2-a655-a8cf6937712a-clzzk was terminated, reason: Error, message: None
2024-09-04 11:09:04,959 | root | kubernetes_job_monitor | WARNING | DeadlineExceeded: The job was killed due to exceeding timeout of 3 seconds.
2024-09-04 11:09:09,059 | root | MainThread | INFO | Workflow c80f79cc-1acc-47c7-bb03-6b6ce57cc60c finished. Files available at /var/reana/users/00000000-0000-0000-0000-000000000000/workflows/c80f79cc-1acc-47c7-bb03-6b6ce57cc60c.
```

Eviction:

```
2024-09-04 11:52:45,493 | root | MainThread | INFO | Publishing step:0, cmd: python "code/helloworld.py" --inputfile "data/names.txt" --outputfile "results/greetings.txt" --sleeptime 1, total steps 1 to MQ
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING | Job reana-run-job-e8494ddb-cc11-40b3-94b9-caa39ad74003-tbstk was terminated, reason: Error, message: None
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING | Job reana-run-job-e8494ddb-cc11-40b3-94b9-caa39ad74003 was disrupted: Eviction API: evicting, reason: EvictionByEvictionAPI
2024-09-04 11:53:09,563 | root | MainThread | INFO | Workflow 7ed08030-414e-4389-9ee3-a1c1ecbe400e finished. Files available at /var/reana/users/00000000-0000-0000-0000-000000000000/workflows/7ed08030-414e-4389-9ee3-a1c1ecbe400e.
```

Without multiline formatter it will not be possible to properly display multiline errors to REANA users using FluentBit.

Old multiline format:

```
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING | line 1
    line2
        line3
```

New format:

```
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING | line 1
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING |     line 2
2024-09-04 11:53:03,719 | root | kubernetes_job_monitor | WARNING |         line 3
```

With old format, FluentBit drops `line 2` and `line 3` logs, so the user only sees `line 1`. With new format, it saves all lines.

feat(utils): add multiline log formatter (#468)
feat(job_manager): log pod errors to warning (#468)
feat(job_monitor): log pod errors, disruptions to warning (#468)