### PR TITLE
feat(kubernetes): add resource settings in kubernetess jobs

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,11 +78,20 @@
         "kerberos": {
           "type": "boolean"
         },
+        "kubernetes_cpu_limit": {
+          "type": "string"
+        },
+        "kubernetes_cpu_request": {
+          "type": "string"
+        },
         "kubernetes_job_timeout": {
           "format": "int32",
           "type": "integer"
         },
         "kubernetes_memory_limit": {
+          "type": "string"
+        },
+        "kubernetes_memory_request": {
           "type": "string"
         },
         "kubernetes_uid": {

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -109,8 +109,59 @@ RUCIO_CERN_BUNDLE_CACHE_FILENAME = "CERN-bundle.pem"
 IMAGE_PULL_SECRETS = os.getenv("IMAGE_PULL_SECRETS", "").split(",")
 """Docker image pull secrets which allow the usage of private images."""
 
+REANA_KUBERNETES_JOBS_CPU_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_CPU_REQUEST")
+"""Default cpu request for user job containers.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu.
+"""
+
+REANA_KUBERNETES_JOBS_CPU_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_CPU_LIMIT")
+"""Default cpu limit for user job containers. Exceeding this limit will terminate the container.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu.
+"""
+
+REANA_KUBERNETES_JOBS_MEMORY_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_REQUEST")
+"""Default memory request for user job containers.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.
+"""
+
 REANA_KUBERNETES_JOBS_MEMORY_LIMIT = os.getenv("REANA_KUBERNETES_JOBS_MEMORY_LIMIT")
-"""Maximum default memory limit for user job containers. Exceeding this limit will terminate the container.
+"""Default memory limit for user job containers. Exceeding this limit will terminate the container.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.
+"""
+
+REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_CPU_REQUEST"
+)
+"""Maximum custom CPU request that users can assign to their job containers via
+``kubernetes_cpu_request`` in reana.yaml.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu.
+"""
+
+REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT"
+)
+"""Maximum custom CPU limit that users can assign to their job containers via
+``kubernetes_cpu_limit`` in reana.yaml. Exceeding this limit will terminate the container.
+
+Please see the following URL for possible values
+https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu.
+"""
+
+REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST = os.getenv(
+    "REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST"
+)
+"""Maximum custom memory request that users can assign to their job containers via
+``kubernetes_memory_request`` in reana.yaml.
 
 Please see the following URL for possible values
 https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -18,6 +18,8 @@ from sqlalchemy.exc import OperationalError
 from reana_commons.errors import (
     REANAKubernetesMemoryLimitExceeded,
     REANAKubernetesWrongMemoryFormat,
+    REANAKubernetesCPULimitExceeded,
+    REANAKubernetesWrongCPUFormat,
 )
 
 from reana_db.models import JobStatus
@@ -273,6 +275,10 @@ def create_job():  # noqa
         job_manager_cls = current_app.config["COMPUTE_BACKENDS"][compute_backend]()
         try:
             job_obj = job_manager_cls(**job_request)
+        except REANAKubernetesCPULimitExceeded as e:
+            return jsonify({"message": e.message}), 403
+        except REANAKubernetesWrongCPUFormat as e:
+            return jsonify({"message": e.message}), 400
         except REANAKubernetesMemoryLimitExceeded as e:
             return jsonify({"message": e.message}), 403
         except REANAKubernetesWrongMemoryFormat as e:

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -49,6 +49,9 @@ class JobRequest(Schema):
     voms_proxy = fields.Bool(required=False)
     rucio = fields.Bool(required=False)
     kubernetes_uid = fields.Int(required=False)
+    kubernetes_cpu_request = fields.Str(required=False)
+    kubernetes_cpu_limit = fields.Str(required=False)
+    kubernetes_memory_request = fields.Str(required=False)
     kubernetes_memory_limit = fields.Str(required=False)
     kubernetes_job_timeout = fields.Int(required=False)
     unpacked_img = fields.Bool(required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ apispec[yaml]==3.3.2      # via apispec-webframeworks, reana-job-controller (set
 apispec-webframeworks==0.5.2  # via reana-job-controller (setup.py)
 appdirs==1.4.4            # via fs
 attrs==23.2.0             # via jsonschema
-backports-zoneinfo[tzdata]==0.2.1  # via backports-zoneinfo, kombu
+backports-zoneinfo[tzdata]==0.2.1  # via kombu
 bcrypt==4.1.2             # via paramiko
 bracex==2.4               # via wcmatch
 bravado==10.3.2           # via reana-commons
@@ -37,7 +37,6 @@ jsonref==1.1.0            # via bravado-core
 jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.3.5              # via reana-commons
 kubernetes==22.6.0        # via reana-commons
-libmytoken==0.1.0
 mako==1.3.2               # via alembic
 markupsafe==2.1.5         # via jinja2, mako, werkzeug
 marshmallow==2.20.1       # via reana-job-controller (setup.py)
@@ -46,19 +45,18 @@ monotonic==1.6            # via bravado
 msgpack==1.0.7            # via bravado-core
 msgpack-python==0.5.6     # via bravado
 oauthlib==3.2.2           # via requests-oauthlib
-paramiko[gssapi]==3.4.0   # via -r requirements.in, paramiko
+paramiko[gssapi]==3.4.0   # via -r requirements.in
 psycopg2-binary==2.9.9    # via reana-db
 pyasn1==0.5.1             # via paramiko, pyasn1-modules, rsa
 pyasn1-modules==0.3.0     # via google-auth
 pycparser==2.21           # via cffi
-pyjwt==2.8.0
 pynacl==1.5.0             # via paramiko
 pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.9.0    # via bravado, bravado-core, kubernetes
 pytz==2024.1              # via bravado-core
 pyyaml==6.0.1             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.9	# via reana-db, reana-job-controller (setup.py)
-reana-db==0.9.5	# via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.9.11  # via reana-db, reana-job-controller (setup.py)
+reana-db==0.9.5           # via reana-job-controller (setup.py)
 requests==2.31.0          # via bravado, bravado-core, kubernetes, requests-oauthlib
 requests-oauthlib==1.3.1  # via kubernetes
 retrying==1.3.4           # via reana-job-controller (setup.py)
@@ -67,7 +65,7 @@ rsa==4.9                  # via google-auth
 simplejson==3.19.2        # via bravado, bravado-core
 six==1.16.0               # via bravado, bravado-core, fs, gssapi, jsonschema, kubernetes, mock, python-dateutil, retrying
 sqlalchemy==1.3.24        # via alembic, reana-db, sqlalchemy-utils
-sqlalchemy-utils[encrypted]==0.41.1  # via reana-db, sqlalchemy-utils
+sqlalchemy-utils[encrypted]==0.41.1  # via reana-db
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.3  # via bravado-core
 typing-extensions==4.10.0  # via alembic, bravado, kombu, swagger-spec-validator

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -69,7 +69,7 @@ install_requires = [
     "Werkzeug>=2.1.0,<3.0",
     "fs>=2.0",
     "marshmallow>2.13.0,<=2.20.1",
-    "reana-commons[kubernetes]>=0.9.9,<0.10.0",
+    "reana-commons[kubernetes]>=0.9.11,<0.10.0",
     "reana-db>=0.9.5,<0.10.0",
     "retrying>=1.3.3",
 ]


### PR DESCRIPTION
Add the following settings to the Kubernetes job spec, either from user-defined values in `reana.yaml` or from administrator-defined defaults.

- `spec.containers[].resources.requests.cpu`
- `spec.containers[].resources.requests.memory`
- `spec.containers[].resources.limits.cpu`
- `spec.containers[].resources.limits.memory`.

Closes reanahub/reana#883