### PR TITLE
ci: add remaining linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,31 @@ jobs:
           npm install jsonlint --global
           ./run-tests.sh --check-jsonlint
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --check-markdownlint
+
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --check-shfmt
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,20 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --check-prettier
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:
@@ -251,8 +265,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-24.04
     if: >
-      vars.RELEASE_DOCKER == 'true' &&
-      github.event_name == 'push' &&
+      vars.RELEASE_DOCKER == 'true' && github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
       - docs-sphinx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,19 @@ jobs:
           pip install yamllint
           ./run-tests.sh --check-yamllint
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --check-jsonlint
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow multiple headings with same content (for different releases)
+MD024: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.pytest_cache
+CHANGELOG.md
+docs/openapi.json

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
+<!-- markdownlint-disable MD013 -->
+
 # Changelog
 
 ## [0.9.4](https://github.com/reanahub/reana-job-controller/compare/0.9.3...0.9.4) (2024-11-29)
-
 
 ### Build
 
@@ -9,11 +10,9 @@
 * **docker:** pin setuptools 70 ([#465](https://github.com/reanahub/reana-job-controller/issues/465)) ([c593d9b](https://github.com/reanahub/reana-job-controller/commit/c593d9bc84763f142573396be48c762eefa8f6ec))
 * **python:** bump shared REANA packages as of 2024-11-28 ([#477](https://github.com/reanahub/reana-job-controller/issues/477)) ([9cdd06c](https://github.com/reanahub/reana-job-controller/commit/9cdd06c72faa5ded628b2766113ab37ac06f5868))
 
-
 ### Features
 
 * **backends:** add new Compute4PUNCH backend ([#430](https://github.com/reanahub/reana-job-controller/issues/430)) ([4243252](https://github.com/reanahub/reana-job-controller/commit/42432522c8d9dd5e4ee908a16b1be87046908e08))
-
 
 ### Bug fixes
 
@@ -25,7 +24,6 @@
 
 ## [0.9.3](https://github.com/reanahub/reana-job-controller/compare/0.9.2...0.9.3) (2024-03-04)
 
-
 ### Build
 
 * **certificates:** update expired CERN Grid CA certificate ([#440](https://github.com/reanahub/reana-job-controller/issues/440)) ([8d6539a](https://github.com/reanahub/reana-job-controller/commit/8d6539a94af035aca1191c9a6a7ff43791a3c930)), closes [#439](https://github.com/reanahub/reana-job-controller/issues/439)
@@ -33,21 +31,17 @@
 * **python:** bump all required packages as of 2024-03-04 ([#442](https://github.com/reanahub/reana-job-controller/issues/442)) ([de119eb](https://github.com/reanahub/reana-job-controller/commit/de119eb8f663dcfe1a126747a7c404e39ece47c0))
 * **python:** bump shared REANA packages as of 2024-03-04 ([#442](https://github.com/reanahub/reana-job-controller/issues/442)) ([fc77628](https://github.com/reanahub/reana-job-controller/commit/fc776284abe15030581d5adf4aa575f4f3a1c756))
 
-
 ### Features
 
 * **shutdown:** stop all running jobs before stopping workflow ([#423](https://github.com/reanahub/reana-job-controller/issues/423)) ([866675b](https://github.com/reanahub/reana-job-controller/commit/866675b7288e840130cfee851f4a248a9ae2617d))
-
 
 ### Bug fixes
 
 * **database:** limit the number of open database connections ([#437](https://github.com/reanahub/reana-job-controller/issues/437)) ([980f749](https://github.com/reanahub/reana-job-controller/commit/980f74982b75176c5958f09bc581e941cdf44310))
 
-
 ### Performance improvements
 
 * **cache:** avoid caching jobs when the cache is disabled ([#435](https://github.com/reanahub/reana-job-controller/issues/435)) ([553468f](https://github.com/reanahub/reana-job-controller/commit/553468f55f6b63cebba45ccd460593131e5dcfea)), closes [#422](https://github.com/reanahub/reana-job-controller/issues/422)
-
 
 ### Code refactoring
 
@@ -56,11 +50,9 @@
 * **monitor:** centralise logs and status updates ([#423](https://github.com/reanahub/reana-job-controller/issues/423)) ([3685b01](https://github.com/reanahub/reana-job-controller/commit/3685b01a57e1d0b1bd363534ff331b988e04719e))
 * **monitor:** move fetching of logs to job-manager ([#423](https://github.com/reanahub/reana-job-controller/issues/423)) ([1fc117e](https://github.com/reanahub/reana-job-controller/commit/1fc117ebb3dd908a01ee3fd539fa24a07cdb4d16))
 
-
 ### Code style
 
 * **black:** format with black v24 ([#426](https://github.com/reanahub/reana-job-controller/issues/426)) ([8a2757e](https://github.com/reanahub/reana-job-controller/commit/8a2757ee8bf52d1d5189f1dd1d690cb8922599cb))
-
 
 ### Continuous integration
 
@@ -72,166 +64,165 @@
 * **release-please:** update version in Dockerfile/OpenAPI specs ([#421](https://github.com/reanahub/reana-job-controller/issues/421)) ([e6742f2](https://github.com/reanahub/reana-job-controller/commit/e6742f2911df46dfbef3b7e9104330d58e2b4211))
 * **shellcheck:** fix exit code propagation ([#425](https://github.com/reanahub/reana-job-controller/issues/425)) ([8e74a85](https://github.com/reanahub/reana-job-controller/commit/8e74a85c90df00c8734a6cdd81597f583d11d566))
 
-
 ### Documentation
 
 * **authors:** complete list of contributors ([#434](https://github.com/reanahub/reana-job-controller/issues/434)) ([b9f8364](https://github.com/reanahub/reana-job-controller/commit/b9f83647fa8fc337140da5c3f2814ea24a15c5d5))
 
 ## 0.9.2 (2023-12-12)
 
-- Adds metadata labels to Dockerfile.
-- Adds automated multi-platform container image building for amd64 and arm64 architectures.
-- Changes CVMFS support to allow users to automatically mount any available repository.
-- Fixes container image building on the arm64 architecture.
-- Fixes the creation of Kubernetes jobs by retrying in case of error and by correctly handling the error after reaching the retry limit.
-- Fixes job monitoring in cases when job creation fails, for example when it is not possible to successfully mount volumes.
+* Adds metadata labels to Dockerfile.
+* Adds automated multi-platform container image building for amd64 and arm64 architectures.
+* Changes CVMFS support to allow users to automatically mount any available repository.
+* Fixes container image building on the arm64 architecture.
+* Fixes the creation of Kubernetes jobs by retrying in case of error and by correctly handling the error after reaching the retry limit.
+* Fixes job monitoring in cases when job creation fails, for example when it is not possible to successfully mount volumes.
 
 ## 0.9.1 (2023-09-27)
 
-- Adds unique error messages to Kubernetes job monitor to more easily identify source of problems.
-- Changes Paramiko to version 3.0.0.
-- Changes HTCondor to version 9.0.17 (LTS).
-- Changes Rucio authentication helper to version 1.1.1 allowing users to override the Rucio server and authentication hosts independently of VO name.
-- Fixes intermittent Slurm connection issues by DNS-resolving the Slurm head node IPv4 address before establishing connections.
-- Fixes deletion of failed jobs not being performed when Kerberos is enabled.
-- Fixes job monitoring to consider OOM-killed jobs as failed.
-- Fixes Slurm command generation issues when using fully-qualified image names.
-- Fixes location of HTCondor build dependencies.
-- Fixes detection of default Rucio server and authentication host for ATLAS VO.
-- Fixes container image names to be Podman-compatible.
+* Adds unique error messages to Kubernetes job monitor to more easily identify source of problems.
+* Changes Paramiko to version 3.0.0.
+* Changes HTCondor to version 9.0.17 (LTS).
+* Changes Rucio authentication helper to version 1.1.1 allowing users to override the Rucio server and authentication hosts independently of VO name.
+* Fixes intermittent Slurm connection issues by DNS-resolving the Slurm head node IPv4 address before establishing connections.
+* Fixes deletion of failed jobs not being performed when Kerberos is enabled.
+* Fixes job monitoring to consider OOM-killed jobs as failed.
+* Fixes Slurm command generation issues when using fully-qualified image names.
+* Fixes location of HTCondor build dependencies.
+* Fixes detection of default Rucio server and authentication host for ATLAS VO.
+* Fixes container image names to be Podman-compatible.
 
 ## 0.9.0 (2023-01-20)
 
-- Adds support for Rucio authentication for workflow jobs.
-- Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
-- Adds Kerberos sidecar container to renew ticket periodically for long-running jobs.
-- Changes `reana-auth-vomsproxy` sidecar to the latest stable version to support client-side proxy file generation technique and ESCAPE VOMS.
-- Changes default Slurm partition to `inf-short`.
-- Changes to PostgreSQL 12.13.
-- Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
+* Adds support for Rucio authentication for workflow jobs.
+* Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
+* Adds Kerberos sidecar container to renew ticket periodically for long-running jobs.
+* Changes `reana-auth-vomsproxy` sidecar to the latest stable version to support client-side proxy file generation technique and ESCAPE VOMS.
+* Changes default Slurm partition to `inf-short`.
+* Changes to PostgreSQL 12.13.
+* Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
 
 ## 0.8.1 (2022-02-07)
 
-- Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
-- Adds a new condition to allow processing jobs in case of receiving multiple failed events when job containers are not in a running state.
+* Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
+* Adds a new condition to allow processing jobs in case of receiving multiple failed events when job containers are not in a running state.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds database connection closure after each REST API request.
-- Adds labels to job and run-batch pods to reduce k8s events to listen to for `job-monitor`.
-- Fixes auto-mounting of Kubernetes API token inside user jobs by disabling it.
-- Changes job dispatching to use only job-specific node labels.
-- Changes to PostgreSQL 12.8.
+* Adds database connection closure after each REST API request.
+* Adds labels to job and run-batch pods to reduce k8s events to listen to for `job-monitor`.
+* Fixes auto-mounting of Kubernetes API token inside user jobs by disabling it.
+* Changes job dispatching to use only job-specific node labels.
+* Changes to PostgreSQL 12.8.
 
 ## 0.7.5 (2021-07-05)
 
-- Changes HTCondor to 8.9.11.
-- Changes myschedd package and configuration to latest versions.
-- Fixes job command formatting bug for CWL workflows on HTCondor.
+* Changes HTCondor to 8.9.11.
+* Changes myschedd package and configuration to latest versions.
+* Fixes job command formatting bug for CWL workflows on HTCondor.
 
 ## 0.7.4 (2021-04-28)
 
-- Adds configuration environment variable to set job memory limits for the Kubernetes compute backend (`REANA_KUBERNETES_JOBS_MEMORY_LIMIT`).
-- Fixes Kubernetes job log capture to include information about failures caused by external factors such as OOMKilled.
-- Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
+* Adds configuration environment variable to set job memory limits for the Kubernetes compute backend (`REANA_KUBERNETES_JOBS_MEMORY_LIMIT`).
+* Fixes Kubernetes job log capture to include information about failures caused by external factors such as OOMKilled.
+* Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
 
 ## 0.7.3 (2021-03-17)
 
-- Adds new configuration to toggle Kubernetes user jobs clean up.
-- Fixes HTCondor Docker networking and machine version requirement setup.
-- Fixes HTCondor logs and workspace files retrieval on job failure.
-- Fixes Slurm job submission providing the correct shell environment to run Singularity.
-- Changes HTCondor myschedd to the latest version.
-- Changes job status `succeeded` to `finished` to use central REANA nomenclature.
-- Changes how to deserialise job commands using central REANA-Commons deserialiser function.
+* Adds new configuration to toggle Kubernetes user jobs clean up.
+* Fixes HTCondor Docker networking and machine version requirement setup.
+* Fixes HTCondor logs and workspace files retrieval on job failure.
+* Fixes Slurm job submission providing the correct shell environment to run Singularity.
+* Changes HTCondor myschedd to the latest version.
+* Changes job status `succeeded` to `finished` to use central REANA nomenclature.
+* Changes how to deserialise job commands using central REANA-Commons deserialiser function.
 
 ## 0.7.2 (2021-02-03)
 
-- Fixes minor code warnings.
-- Changes CI system to include Python flake8 and Dockerfile hadolint checkers.
+* Fixes minor code warnings.
+* Changes CI system to include Python flake8 and Dockerfile hadolint checkers.
 
 ## 0.7.1 (2020-11-10)
 
-- Adds support for specifying `htcondor_max_runtime` and `htcondor_accounting_group` for HTCondor compute backend jobs.
-- Fixes Docker build by properly exiting when there are problems with `myschedd` installation.
+* Adds support for specifying `htcondor_max_runtime` and `htcondor_accounting_group` for HTCondor compute backend jobs.
+* Fixes Docker build by properly exiting when there are problems with `myschedd` installation.
 
 ## 0.7.0 (2020-10-20)
 
-- Adds support for running unpacked Docker images from CVMFS on HTCondor jobs.
-- Adds support for pulling private images using image pull secrets.
-- Adds support for VOMS proxy as a new authentication method.
-- Adds pinning of all Python dependencies allowing to easily rebuild component images at later times.
-- Fixes HTCondor job submission retry technique.
-- Changes error reporting on Docker image related failures.
-- Changes runtime pods to prefix user workflows with the configured REANA prefix.
-- Changes CVMFS to be read-only mount.
-- Changes runtime job instantiation into the configured runtime namespace.
-- Changes test suite to enable running tests locally also on macOS platform.
-- Changes CERN HTCondor compute backend to use the new `myschedd` connection library.
-- Changes CERN Slurm compute backend to improve job status detection.
-- Changes base image to use Python 3.8.
-- Changes code formatting to respect `black` coding style.
-- Changes documentation to single-page layout.
+* Adds support for running unpacked Docker images from CVMFS on HTCondor jobs.
+* Adds support for pulling private images using image pull secrets.
+* Adds support for VOMS proxy as a new authentication method.
+* Adds pinning of all Python dependencies allowing to easily rebuild component images at later times.
+* Fixes HTCondor job submission retry technique.
+* Changes error reporting on Docker image related failures.
+* Changes runtime pods to prefix user workflows with the configured REANA prefix.
+* Changes CVMFS to be read-only mount.
+* Changes runtime job instantiation into the configured runtime namespace.
+* Changes test suite to enable running tests locally also on macOS platform.
+* Changes CERN HTCondor compute backend to use the new `myschedd` connection library.
+* Changes CERN Slurm compute backend to improve job status detection.
+* Changes base image to use Python 3.8.
+* Changes code formatting to respect `black` coding style.
+* Changes documentation to single-page layout.
 
 ## 0.6.1 (2020-05-25)
 
-- Upgrades REANA-Commons package using latest Kubernetes Python client version.
+* Upgrades REANA-Commons package using latest Kubernetes Python client version.
 
 ## 0.6.0 (2019-12-20)
 
-- Adds generic job manager class and provides example classes for CERN HTCondor
+* Adds generic job manager class and provides example classes for CERN HTCondor
   and CERN Slurm clusters.
-- Moves job controller to the same Kubernetes pod with the
+* Moves job controller to the same Kubernetes pod with the
   REANA-Workflow-Engine-\* (sidecar pattern).
-- Adds sidecar container to the Kubernetes job pod if Kerberos authentication
+* Adds sidecar container to the Kubernetes job pod if Kerberos authentication
   is required.
-- Provides user secrets to the job container runtime tasks.
-- Refactors job monitoring using singleton pattern.
+* Provides user secrets to the job container runtime tasks.
+* Refactors job monitoring using singleton pattern.
 
 ## 0.5.1 (2019-04-23)
 
-- Pins `urllib3` due to a conflict while installing `Kubernetes` Python
+* Pins `urllib3` due to a conflict while installing `Kubernetes` Python
   library.
-- Fixes documenation build badge.
+* Fixes documenation build badge.
 
 ## 0.5.0 (2019-04-23)
 
-- Adds a new endpoint to delete jobs (Kubernetes).
-- Introduces new common interface for job management which defines what the
+* Adds a new endpoint to delete jobs (Kubernetes).
+* Introduces new common interface for job management which defines what the
   compute backends should offer to be compatible with REANA, currently only
   Kubernetes backend is supported.
-- Fixes security vulnerability which allowed users to access other people's
+* Fixes security vulnerability which allowed users to access other people's
   workspaces.
-- Makes CVMFS mounts optional and configurable at repository level.
-- Updates the creation of CVMFS volumes specification, it now uses normal
+* Makes CVMFS mounts optional and configurable at repository level.
+* Updates the creation of CVMFS volumes specification, it now uses normal
   persistent volume claims.
-- Increases stability and improves test coverage.
+* Increases stability and improves test coverage.
 
 ## 0.4.0 (2018-11-06)
 
-- Improves REST API documentation rendering.
-- Changes license to MIT.
+* Improves REST API documentation rendering.
+* Changes license to MIT.
 
 ## 0.3.2 (2018-09-26)
 
-- Adapts Kubernetes API adaptor to mount shared volumes on jobs as CEPH
+* Adapts Kubernetes API adaptor to mount shared volumes on jobs as CEPH
   `persistentVolumeClaim`'s (managed by `reana-cluster`) instead of plain
   CEPH volumes.
 
 ## 0.3.1 (2018-09-07)
 
-- Pins REANA-Commons and REANA-DB dependencies.
+* Pins REANA-Commons and REANA-DB dependencies.
 
 ## 0.3.0 (2018-08-10)
 
-- Adds uwsgi for production deployments.
-- Switches from pykube to official Kubernetes python client.
-- Adds compatibility with latest Kubernetes.
+* Adds uwsgi for production deployments.
+* Switches from pykube to official Kubernetes python client.
+* Adds compatibility with latest Kubernetes.
 
 ## 0.2.0 (2018-04-19)
 
-- Adds dockerignore file to ease developments.
+* Adds dockerignore file to ease developments.
 
 ## 0.1.0 (2018-01-30)
 
-- Initial public release.
+* Initial public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome.
+If you find a demonstrable problem that is caused by the REANA code, please:
 
 1. Search for [already reported problems](https://github.com/reanahub/reana-job-controller/issues).
 2. Check if the issue has been fixed or is still reproducible on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome.
-If you find a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/reana-job-controller/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/reana-job-controller/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,3 +34,5 @@ recursive-include etc *.yaml
 recursive-include etc *.sh
 include etc/ngbauth-submit
 include krb5/Dockerfile
+exclude .editorconfig
+exclude .prettierignore

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 ## About
 
 REANA-Job-Controller is a component of the [REANA](http://www.reana.io/)
-reusable and reproducible research data analysis platform. It takes care
-of executing and managing jobs on compute clouds.
+reusable and reproducible research data analysis platform. It takes care of
+executing and managing jobs on compute clouds.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 ## About
 
-REANA-Job-Controller is a component of the [REANA](http://www.reana.io/) reusable and
-reproducible research data analysis platform. It takes care of executing and managing
-jobs on compute clouds.
+REANA-Job-Controller is a component of the [REANA](http://www.reana.io/)
+reusable and reproducible research data analysis platform. It takes care
+of executing and managing jobs on compute clouds.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ compute backends.
 ```
 
 ```{image} /_static/reana-job-manager.png
+
 ```
 
 ### Kubernetes
@@ -32,10 +33,8 @@ compute backends.
    :members:
 ```
 
-:::{note}
-REANA-Job-Controller supports the Kubernetes job manager by default, no need
-to pass any build argument.
-:::
+Note that REANA-Job-Controller supports the Kubernetes job manager by default,
+no need to pass any build argument.
 
 ### HTCondor
 
@@ -44,16 +43,14 @@ to pass any build argument.
    :members:
 ```
 
-:::{note}
-To build REANA-Job-Controller Docker image with HTCondor dependencies use build
-argument `COMPUTE_BACKENDS=kubernetes,htcondorcern`.
+Note that in order to build REANA-Job-Controller Docker image with HTCondor
+dependencies, you need to use a build argument
+`COMPUTE_BACKENDS=kubernetes,htcondorcern`:
 
 ```console
 $ reana-dev docker-build -c reana-job-controller \
   -b COMPUTE_BACKENDS=kubernetes,htcondorcern
 ```
-
-:::
 
 ### Slurm
 
@@ -62,27 +59,20 @@ $ reana-dev docker-build -c reana-job-controller \
    :members:
 ```
 
-:::{note}
-To build REANA-Job-Controller Docker image with Slum dependencies use build
-argument `COMPUTE_BACKENDS=kubernetes,slurmcern`.
+Note that in order to build REANA-Job-Controller Docker image with Slurm
+dependencies, you need to use a build argument
+`COMPUTE_BACKENDS=kubernetes,slurmcern`:
 
 ```console
 $ reana-dev docker-build -c reana-job-controller \
   -b COMPUTE_BACKENDS=kubernetes,slurmcern
 ```
 
-:::
-
-:::{note}
-Please note that CERN Slurm cluster access is not granted by
-[default](https://batchdocs.web.cern.ch/linuxhpc/access.html).
-:::
-
 ## REST API
 
 The REANA Job Controller API offers different endpoints to create, manage and
-monitor jobs.
-Detailed REST API documentation can be found <a href="_static/api.html">here</a>.
+monitor jobs. Detailed REST API documentation can be found
+<a href="_static/api.html">here</a>.
 
 ```{eval-rst}
 .. automodule:: reana_job_controller.rest

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```
@@ -49,6 +52,7 @@ argument `COMPUTE_BACKENDS=kubernetes,htcondorcern`.
 $ reana-dev docker-build -c reana-job-controller \
   -b COMPUTE_BACKENDS=kubernetes,htcondorcern
 ```
+
 :::
 
 ### Slurm
@@ -66,6 +70,7 @@ argument `COMPUTE_BACKENDS=kubernetes,slurmcern`.
 $ reana-dev docker-build -c reana-job-controller \
   -b COMPUTE_BACKENDS=kubernetes,slurmcern
 ```
+
 :::
 
 :::{note}
@@ -75,7 +80,8 @@ Please note that CERN Slurm cluster access is not granted by
 
 ## REST API
 
-The REANA Job Controller API offers different endpoints to create, manage and monitor jobs.
+The REANA Job Controller API offers different endpoints to create, manage and
+monitor jobs.
 Detailed REST API documentation can be found <a href="_static/api.html">here</a>.
 
 ```{eval-rst}

--- a/etc/job_wrapper.sh
+++ b/etc/job_wrapper.sh
@@ -13,7 +13,7 @@ echo "command to execute:"
 # shellcheck disable=SC2068,SC2294
 eval $@
 
-echo "$@" "|bash" > "$tmpjob"
+echo "$@" "|bash" >"$tmpjob"
 bash "$tmpjob"
 res=$?
 rm "$tmpjob"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -131,6 +131,10 @@ check_markdownlint() {
     markdownlint-cli2 "**/*.md" -i "node_modules/**"
 }
 
+check_prettier() {
+    prettier -c .
+}
+
 check_pytest() {
     clean_old_db_container
     start_db_container
@@ -164,6 +168,7 @@ check_all() {
     check_shfmt
     check_jsonlint
     check_markdownlint
+    check_prettier
 }
 
 check_all_darwin() {
@@ -215,6 +220,7 @@ case $arg in
 --check-jsonlint) check_jsonlint ;;
 --check-pytest) check_pytest ;;
 --check-shfmt) check_shfmt ;;
+--check-prettier) check_prettier ;;
 --check-markdownlint) check_markdownlint ;;
 --check-yamllint) check_yamllint ;;
 --check-all) check_all ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -127,6 +127,10 @@ check_shfmt() {
     shfmt -d .
 }
 
+check_markdownlint() {
+    markdownlint-cli2 "**/*.md" -i "node_modules/**"
+}
+
 check_pytest() {
     clean_old_db_container
     start_db_container
@@ -159,6 +163,7 @@ check_all() {
     check_yamllint
     check_shfmt
     check_jsonlint
+    check_markdownlint
 }
 
 check_all_darwin() {
@@ -210,6 +215,7 @@ case $arg in
 --check-jsonlint) check_jsonlint ;;
 --check-pytest) check_pytest ;;
 --check-shfmt) check_shfmt ;;
+--check-markdownlint) check_markdownlint ;;
 --check-yamllint) check_yamllint ;;
 --check-all) check_all ;;
 --check-dockerfile) check_dockerfile ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,25 +14,23 @@ DOCKER_IMAGE_NAME=docker.io/reanahub/$COMPONENT_NAME
 PLATFORM="$(python -c 'import platform; print(platform.system())')"
 
 # Verify that db container is running before continuing
-_check_ready () {
+_check_ready() {
     RETRIES=40
-    while ! $2
-    do
+    while ! $2; do
         echo "==> [INFO] Waiting for $1, $((RETRIES--)) remaining attempts..."
         sleep 2
-        if [ $RETRIES -eq 0 ]
-        then
+        if [ $RETRIES -eq 0 ]; then
             echo "==> [ERROR] Couldn't reach $1"
             exit 1
         fi
     done
 }
 
-_db_check () {
-    docker exec --user postgres postgres__reana-job-controller bash -c "pg_isready" &>/dev/null;
+_db_check() {
+    docker exec --user postgres postgres__reana-job-controller bash -c "pg_isready" &>/dev/null
 }
 
-clean_old_db_container () {
+clean_old_db_container() {
     OLD="$(docker ps --all --quiet --filter=name=postgres__reana-job-controller)"
     if [ -n "$OLD" ]; then
         echo '==> [INFO] Cleaning old DB container...'
@@ -40,7 +38,7 @@ clean_old_db_container () {
     fi
 }
 
-start_db_container () {
+start_db_container() {
     echo '==> [INFO] Starting DB container...'
     docker run --rm --name postgres__reana-job-controller -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d docker.io/library/postgres:14.10
     _check_ready "Postgres" _db_check
@@ -52,12 +50,12 @@ start_db_container () {
     export REANA_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:mysecretpassword@$db_container_ip/postgres
 }
 
-stop_db_container () {
+stop_db_container() {
     echo '==> [INFO] Stopping DB container...'
     docker stop postgres__reana-job-controller
 }
 
-check_commitlint () {
+check_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -79,7 +77,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -91,37 +89,41 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+check_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_pydocstyle () {
+check_pydocstyle() {
     pydocstyle reana_job_controller
 }
 
-check_black () {
+check_black() {
     black --check .
 }
 
-check_flake8 () {
+check_flake8() {
     flake8 .
 }
 
-check_openapi_spec () {
+check_openapi_spec() {
     FLASK_APP=reana_job_controller/app.py flask openapi create openapi.json
     diff -q -w openapi.json docs/openapi.json
     rm openapi.json
 }
 
-check_manifest () {
+check_manifest() {
     check-manifest
 }
 
-check_sphinx () {
+check_sphinx() {
     sphinx-build -qnN docs docs/_build/html
 }
 
-check_pytest () {
+check_shfmt() {
+    shfmt -d .
+}
+
+check_pytest() {
     clean_old_db_container
     start_db_container
     trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
@@ -133,15 +135,15 @@ check_yamllint() {
     yamllint .
 }
 
-check_dockerfile () {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+check_dockerfile() {
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
-check_docker_build () {
+check_docker_build() {
     docker build -t $DOCKER_IMAGE_NAME .
 }
 
-check_all () {
+check_all() {
     check_commitlint
     check_shellcheck
     check_pydocstyle
@@ -151,9 +153,10 @@ check_all () {
     check_manifest
     check_sphinx
     check_yamllint
+    check_shfmt
 }
 
-check_all_darwin () {
+check_all_darwin() {
     # Tests are run inside the docker container because there is
     # no HTCondor Python package for MacOS
     check_dockerfile
@@ -178,31 +181,32 @@ check_all_darwin () {
 
 if [ $# -eq 0 ]; then
     case $PLATFORM in
-    Darwin*) check_all_darwin;;
+    Darwin*) check_all_darwin ;;
     *)
         check_all
         check_pytest
         check_dockerfile
         check_docker_build
-    ;;
+        ;;
     esac
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-openapi-spec) check_openapi_spec;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    --check-yamllint) check_yamllint;;
-    --check-all) check_all;;
-    --check-dockerfile) check_dockerfile;;
-    --check-docker-build) check_docker_build;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--check-commitlint) check_commitlint "$@" ;;
+--check-shellcheck) check_shellcheck ;;
+--check-pydocstyle) check_pydocstyle ;;
+--check-black) check_black ;;
+--check-flake8) check_flake8 ;;
+--check-openapi-spec) check_openapi_spec ;;
+--check-manifest) check_manifest ;;
+--check-sphinx) check_sphinx ;;
+--check-pytest) check_pytest ;;
+--check-shfmt) check_shfmt ;;
+--check-yamllint) check_yamllint ;;
+--check-all) check_all ;;
+--check-dockerfile) check_dockerfile ;;
+--check-docker-build) check_docker_build ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -119,6 +119,10 @@ check_sphinx() {
     sphinx-build -qnN docs docs/_build/html
 }
 
+check_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -154,6 +158,7 @@ check_all() {
     check_sphinx
     check_yamllint
     check_shfmt
+    check_jsonlint
 }
 
 check_all_darwin() {
@@ -202,6 +207,7 @@ case $arg in
 --check-openapi-spec) check_openapi_spec ;;
 --check-manifest) check_manifest ;;
 --check-sphinx) check_sphinx ;;
+--check-jsonlint) check_jsonlint ;;
 --check-pytest) check_pytest ;;
 --check-shfmt) check_shfmt ;;
 --check-yamllint) check_yamllint ;;


### PR DESCRIPTION
Introduce remaining file formatting checks to `run-tests.sh` and to the GitHub CI:
- [x] `jsonlint` for json linting
- [x] `shfmt` for shell script formatting
- [x] `markdownlint` for markdown linting
- [x] `prettier` for various other formatting such as `.js` files
- [x] `.editorconfig` for consistent character formatting across the repo
- [x] Squash 'merge' commits?

Closes #490