### PR TITLE
feat(job-manager): add Kueue scheduling option for user workloads

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,4 @@ The list of contributors in alphabetical order:
 - [Sinclert Perez](https://www.linkedin.com/in/sinclert)
 - [Tibor Simko](https://orcid.org/0000-0001-7202-5803)
 - [Vladyslav Moisieienkov](https://orcid.org/0000-0001-9717-0775)
+- [Xavier Tintin](https://orcid.org/0000-0002-3150-9112)

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -177,6 +177,12 @@ SLURM_SSH_BANNER_TIMEOUT = float(os.getenv("SLURM_SSH_BANNER_TIMEOUT", "60"))
 SLURM_SSH_AUTH_TIMEOUT = float(os.getenv("SLURM_SSH_AUTH_TIMEOUT", "60"))
 """Seconds to wait for SLURM SSH authentication response."""
 
+USE_KUEUE = bool(strtobool(os.getenv("USE_KUEUE", "False")))
+"""Whether to use Kueue to manage job execution."""
+
+KUEUE_LOCAL_QUEUE_NAME = "local-queue-job"
+"""Name of the local queue to be used by Kueue."""
+
 REANA_USER_ID = os.getenv("REANA_USER_ID")
 """User UUID of the owner of the workflow."""
 

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -52,6 +52,8 @@ from reana_job_controller.config import (
     REANA_KUBERNETES_JOBS_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
     REANA_USER_ID,
+    USE_KUEUE,
+    KUEUE_LOCAL_QUEUE_NAME,
 )
 from reana_job_controller.errors import ComputingBackendSubmissionError
 from reana_job_controller.job_manager import JobManager
@@ -155,12 +157,18 @@ class KubernetesJobManager(JobManager):
     def execute(self):
         """Execute a job in Kubernetes."""
         backend_job_id = build_unique_component_name("run-job")
+
         self.job = {
             "kind": "Job",
             "apiVersion": "batch/v1",
             "metadata": {
                 "name": backend_job_id,
                 "namespace": REANA_RUNTIME_KUBERNETES_NAMESPACE,
+                "labels": (
+                    {"kueue.x-k8s.io/queue-name": KUEUE_LOCAL_QUEUE_NAME}
+                    if USE_KUEUE
+                    else {}
+                ),
             },
             "spec": {
                 "backoffLimit": KubernetesJobManager.MAX_NUM_JOB_RESTARTS,


### PR DESCRIPTION
Introduces [Kueue](https://kueue.sigs.k8s.io/docs/overview/) as an alternative way to submit user jobs.

Kueue is disabled by default.

See [related reana PR](https://github.com/reanahub/reana/pull/903) for testing instructions.

Closes https://github.com/reanahub/reana/issues/800