### PR TITLE
build(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install -r requirements.txt
           pip install -e .[all]
 
@@ -227,7 +227,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install -r requirements.txt
           pip install -e .[all]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -y && \
       python3.12 \
       python3.12-dev \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade setuptools && \
+    pip install --no-cache-dir --upgrade 'setuptools<81' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       gcc && \

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[docs]

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -41,7 +41,6 @@ from reana_job_controller.schemas import Job, JobRequest
 from reana_job_controller.utils import update_workflow_logs
 from reana_job_controller import config
 
-
 blueprint = Blueprint("jobs", __name__)
 
 job_request_schema = JobRequest()


### PR DESCRIPTION
Pin setuptools<81 in Dockerfile, CI workflows, and
ReadTheDocs configuration. This is because the recent
setuptools 81.0.0 upgrade removed the pkg_resources
module that is needed at runtime by some dependencies.