### PR TITLE
Adding unpacked containers for kubernetes backend

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -117,6 +117,18 @@ RUCIO_CERN_BUNDLE_CACHE_FILENAME = "CERN-bundle.pem"
 IMAGE_PULL_SECRETS = os.getenv("IMAGE_PULL_SECRETS", "").split(",")
 """Docker image pull secrets which allow the usage of private images."""
 
+REANA_UNPACKED_IMAGE_RUNNER = os.getenv(
+    "REANA_UNPACKED_IMAGE_RUNNER",
+    "ghcr.io/apptainer/apptainer:v1.5.0",
+)
+"""Docker image used to run unpacked /cvmfs container images via Apptainer."""
+
+REANA_UNPACKED_IMAGE_RUNNER_COMMAND = os.getenv(
+    "REANA_UNPACKED_IMAGE_RUNNER_COMMAND",
+    "apptainer",
+)
+"""Command to invoke inside the unpacked image runner (e.g. apptainer or singularity)."""
+
 REANA_KUBERNETES_JOBS_CPU_REQUEST = os.getenv("REANA_KUBERNETES_JOBS_CPU_REQUEST")
 """Default cpu request for user job containers.
 

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -7,6 +7,7 @@
 """Kubernetes Job Manager."""
 
 import ast
+import base64
 import logging
 import os
 import traceback
@@ -47,6 +48,7 @@ from reana_commons.k8s.api_client import (
 from reana_commons.k8s.kerberos import get_kerberos_k8s_config
 from reana_commons.k8s.secrets import UserSecretsStore, UserSecrets
 from reana_commons.k8s.volumes import (
+    extract_cvmfs_repository,
     get_k8s_cvmfs_volumes,
     get_reana_shared_volume,
     get_workspace_volume,
@@ -64,6 +66,8 @@ from reana_job_controller.config import (
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_MIN_USER_UID,
+    REANA_UNPACKED_IMAGE_RUNNER,
+    REANA_UNPACKED_IMAGE_RUNNER_COMMAND,
     REANA_USER_ID,
     KUEUE_ENABLED,
     KUEUE_LOCAL_QUEUE_NAME,
@@ -97,6 +101,7 @@ class KubernetesJobManager(JobManager):
         kubernetes_cpu_limit=None,
         kubernetes_memory_request=None,
         kubernetes_memory_limit=None,
+        unpacked_img=None,
         voms_proxy=False,
         rucio=False,
         kubernetes_job_timeout: Optional[int] = None,
@@ -129,6 +134,10 @@ class KubernetesJobManager(JobManager):
         :type kubernetes_uid: int
         :param kubernetes_memory_limit: Memory limit for job container.
         :type kubernetes_memory_limit: str
+        :param unpacked_img: Force running the job via Apptainer (e.g. for an
+            unpacked CVMFS image). Apptainer is also auto-detected when
+            ``docker_img`` is a ``/cvmfs/`` path or a ``.sif`` file.
+        :type unpacked_img: bool
         :param kubernetes_job_timeout: Job timeout in seconds.
         :type kubernetes_job_timeout: int
         :param voms_proxy: Decides if a voms-proxy certificate should be
@@ -154,6 +163,7 @@ class KubernetesJobManager(JobManager):
         self.cvmfs_mounts = cvmfs_mounts
         self.shared_file_system = shared_file_system
         self.kerberos = kerberos
+        self.unpacked_img = unpacked_img
         self.voms_proxy = voms_proxy
         self.rucio = rucio
         self.set_user_id(kubernetes_uid)
@@ -172,10 +182,80 @@ class KubernetesJobManager(JobManager):
             self._secrets = UserSecretsStore.fetch(REANA_USER_ID)
         return self._secrets
 
+    def _get_singularity_image(self):
+        """Return the image reference to run via Apptainer, or None for native Docker."""
+        if (
+            self.unpacked_img
+            or self.docker_img.startswith("/cvmfs/")
+            or self.docker_img.endswith(".sif")
+        ):
+            return self.docker_img
+        return None
+
+    def _prepare_unpacked_image(self):
+        """Prepare job for execution with a Singularity/Apptainer container image.
+
+        When ``docker_img`` is a CVMFS unpacked path or a ``.sif`` file,
+        the job is wrapped so that:
+        - The pod runs a lightweight Apptainer runner image instead
+        - The original command is executed inside the image via ``apptainer exec``
+        - The workflow workspace is bind-mounted into the container
+        - For CVMFS paths, the required repository is also auto-mounted
+
+        :returns: Tuple of ``(pod_shell, docker_img, cmd, cvmfs_mounts)``.
+            ``pod_shell`` is ``"sh"`` for Apptainer runner images and ``"bash"``
+            for plain Docker images.
+        """
+        singularity_img = self._get_singularity_image()
+        if singularity_img is None:
+            return "bash", self.docker_img, self.cmd, self.cvmfs_mounts
+
+        # Wrap command with base64-encode to avoid quoting issues
+        encoded_cmd = base64.b64encode(self.cmd.encode("utf-8")).decode("utf-8")
+
+        if singularity_img.startswith("/cvmfs/"):
+            # CVMFS unpacked image
+            if self.cvmfs_mounts and self.cvmfs_mounts != "false":
+                try:
+                    cvmfs_repos = ast.literal_eval(self.cvmfs_mounts)
+                except (ValueError, SyntaxError) as e:
+                    raise ValueError(
+                        f"Invalid cvmfs_mounts value {self.cvmfs_mounts!r}: {e}"
+                    ) from e
+            else:
+                cvmfs_repos = []
+
+            repository = extract_cvmfs_repository(singularity_img)
+            if repository not in cvmfs_repos:
+                cvmfs_repos.append(repository)
+            cvmfs_mounts = str(cvmfs_repos)
+
+            cmd = (
+                f"{REANA_UNPACKED_IMAGE_RUNNER_COMMAND} exec"
+                f" --bind /cvmfs"  # also mount the CVMFS repository volume
+                f" --bind {self.workflow_workspace}"
+                f" --pwd {self.workflow_workspace}"
+                f" {singularity_img}"
+                f' bash -c "echo {encoded_cmd} | base64 -d | bash"'
+            )
+        else:
+            # Vanilla Singularity image (.sif file)
+            cvmfs_mounts = self.cvmfs_mounts
+            cmd = (
+                f"{REANA_UNPACKED_IMAGE_RUNNER_COMMAND} exec"
+                f" --bind {self.workflow_workspace}"
+                f" --pwd {self.workflow_workspace}"
+                f" {singularity_img}"
+                f' bash -c "echo {encoded_cmd} | base64 -d | bash"'
+            )
+
+        return "sh", REANA_UNPACKED_IMAGE_RUNNER, cmd, cvmfs_mounts
+
     @JobManager.execution_hook
     def execute(self):
         """Execute a job in Kubernetes."""
         backend_job_id = build_unique_component_name("run-job")
+        pod_shell, docker_img, cmd, cvmfs_mounts = self._prepare_unpacked_image()
 
         self.job = {
             "kind": "Job",
@@ -204,9 +284,9 @@ class KubernetesJobManager(JobManager):
                         "automountServiceAccountToken": False,
                         "containers": [
                             {
-                                "image": self.docker_img,
-                                "command": ["bash", "-c"],
-                                "args": [self.cmd],
+                                "image": docker_img,
+                                "command": [pod_shell, "-c"],
+                                "args": [cmd],
                                 "name": "job",
                                 "env": [],
                                 "volumeMounts": [],
@@ -244,8 +324,8 @@ class KubernetesJobManager(JobManager):
         self.add_image_pull_secrets()
         self.add_kubernetes_job_timeout()
 
-        if self.cvmfs_mounts != "false":
-            cvmfs_repositories = ast.literal_eval(self.cvmfs_mounts)
+        if cvmfs_mounts != "false":
+            cvmfs_repositories = ast.literal_eval(cvmfs_mounts)
             volume_mounts, volumes = get_k8s_cvmfs_volumes(cvmfs_repositories)
             job_spec["containers"][0]["volumeMounts"].extend(volume_mounts)
             job_spec["volumes"].extend(volumes)

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -8,7 +8,9 @@
 
 """REANA-Job-Controller Job Manager tests."""
 
+import base64
 import json
+import re
 import uuid
 
 import mock
@@ -404,3 +406,242 @@ def test_set_user_id(
     else:
         job_manager.set_user_id(kubernetes_uid)
         assert job_manager.kubernetes_uid == expected_value
+
+
+def test_execute_unpacked_cvmfs_image(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test execution of a job with an unpacked /cvmfs image."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    cvmfs_image = "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/library/python:3.9"
+    expected_command = "echo hello world"
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+
+    job_manager = KubernetesJobManager(
+        docker_img=cvmfs_image,
+        cmd=expected_command,
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            kubernetes_client.create_namespaced_job.assert_called_once()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+            container = job_spec["containers"][0]
+
+            # Runner image should be the Apptainer image, not the CVMFS path
+            assert container["image"] == "ghcr.io/apptainer/apptainer:v1.5.0"
+
+            # Pod shell should be 'sh' (Apptainer runner is Alpine-based)
+            assert container["command"] == ["sh", "-c"]
+
+            # Command should contain apptainer exec with the CVMFS path
+            cmd = container["args"][0]
+            assert "apptainer exec" in cmd
+            assert cvmfs_image in cmd
+            assert "--bind /cvmfs" in cmd
+            assert f"--bind {workflow_workspace}" in cmd
+
+            # Base64-encoded command should decode back to original
+            b64_match = re.search(r"echo (\S+) \| base64 -d \| bash", cmd)
+            assert b64_match is not None
+            decoded = base64.b64decode(b64_match.group(1)).decode("utf-8")
+            assert decoded == expected_command
+
+            # CVMFS volume should be mounted
+            cvmfs_mount_paths = [
+                m["mountPath"]
+                for m in container["volumeMounts"]
+                if m.get("name") == "cvmfs"
+            ]
+            assert any("/cvmfs/unpacked.cern.ch" in path for path in cvmfs_mount_paths)
+
+
+def test_unpacked_image_merges_cvmfs_mounts(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that unpacked image auto-adds its CVMFS repo alongside user mounts."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+
+    job_manager = KubernetesJobManager(
+        docker_img="/cvmfs/unpacked.cern.ch/some/image",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        cvmfs_mounts="['sft.cern.ch']",
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+            container = job_spec["containers"][0]
+
+            # Both user-requested and auto-detected repos should be mounted
+            cvmfs_mount_paths = [
+                m["mountPath"]
+                for m in container["volumeMounts"]
+                if m.get("name") == "cvmfs"
+            ]
+            assert any("/cvmfs/sft.cern.ch" in p for p in cvmfs_mount_paths)
+            assert any("/cvmfs/unpacked.cern.ch" in p for p in cvmfs_mount_paths)
+
+
+def test_unpacked_image_special_characters(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that commands with special characters are safely base64-encoded."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+
+    special_cmd = "echo 'hello \"world\"' && cat file.txt | grep -E '^test$'"
+    job_manager = KubernetesJobManager(
+        docker_img="/cvmfs/unpacked.cern.ch/some/image",
+        cmd=special_cmd,
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            cmd = body["spec"]["template"]["spec"]["containers"][0]["args"][0]
+
+            # Extract and decode the base64 payload
+            b64_match = re.search(r"echo (\S+) \| base64 -d \| bash", cmd)
+            assert b64_match is not None
+            decoded = base64.b64decode(b64_match.group(1)).decode("utf-8")
+            assert decoded == special_cmd
+
+
+def test_normal_image_not_affected():
+    """Test that plain Docker images run natively, not via Apptainer."""
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+    )
+    pod_shell, docker_img, cmd, _ = job_manager._prepare_unpacked_image()
+    assert pod_shell == "bash"
+    assert docker_img == "docker.io/library/busybox"
+    assert cmd == "ls"
+
+
+@pytest.mark.parametrize(
+    "singularity_img",
+    [
+        "/workspace/images/my_tool.sif",
+    ],
+)
+def test_singularity_image_uses_apptainer_runner(singularity_img):
+    """Test that .sif paths use the Apptainer runner."""
+    job_manager = KubernetesJobManager(
+        docker_img=singularity_img,
+        cmd="echo hello",
+        env_vars={},
+    )
+    pod_shell, docker_img, cmd, cvmfs_mounts = job_manager._prepare_unpacked_image()
+
+    assert pod_shell == "sh"
+    assert docker_img == "ghcr.io/apptainer/apptainer:v1.5.0"
+    assert "apptainer exec" in cmd
+    assert singularity_img in cmd
+    assert "--bind /cvmfs" not in cmd
+
+    b64_match = re.search(r"echo (\S+) \| base64 -d \| bash", cmd)
+    assert b64_match is not None
+    decoded = base64.b64decode(b64_match.group(1)).decode("utf-8")
+    assert decoded == "echo hello"
+
+
+def test_singularity_sif_does_not_add_cvmfs_volume(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that a .sif image does not trigger CVMFS volume mounting."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+
+    job_manager = KubernetesJobManager(
+        docker_img="/workspace/my_tool.sif",
+        cmd="run_analysis",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+            container = job_spec["containers"][0]
+
+            assert container["image"] == "ghcr.io/apptainer/apptainer:v1.5.0"
+            assert container["command"] == ["sh", "-c"]
+            assert "apptainer exec" in container["args"][0]
+            assert "--bind /cvmfs" not in container["args"][0]
+
+            # No CVMFS volumes should be mounted
+            cvmfs_volumes = [v for v in job_spec["volumes"] if "cvmfs" in v["name"]]
+            assert cvmfs_volumes == []


### PR DESCRIPTION
This PR fixes #483. Here are the changes:

* `config.py` — Two new env-configurable constants:                                                     
  - `REANA_UNPACKED_IMAGE_RUNNER` — Apptainer runner image (default: `ghcr.io/apptainer/apptainer:latest`)
  - `REANA_UNPACKED_IMAGE_RUNNER_COMMAND` — command to invoke (default: `apptainer`, overridable to       
  `singularity`)                                                                                        

* `kubernetes_job_manager.py`:
  - Added `unpacked_img` parameter to `__init__` (was being swallowed by `**kwargs`)
  - Added `_prepare_unpacked_image()` method — when `docker_img` starts with `/cvmfs/`, it:
    - Extracts the CVMFS repository and merges it into `cvmfs_mounts` (so the existing volume plumbing
  handles it)
    - Replaces `docker_img` with the configurable Apptainer runner
    - Base64-encodes the original command and wraps it with `apptainer exec --no-setuid --bind /cvmfs
  --bind <workspace>`
    - Returns `"sh"` as pod shell (Alpine-based runner) instead of `"bash"`
  - Replaced the previous inline hack in `execute()` with a clean call to `_prepare_unpacked_image()`

* `tests/test_job_manager.py` — Four new tests:
  - Full integration test (runner image, shell, command wrapping, CVMFS mount, base64 round-trip)
  - CVMFS mount merging with user-requested mounts
  - Special shell characters survive base64 encoding
  - Normal Docker images are unaffected
  
Depends-On: reanahub/reana-commons#515