### PR TITLE
ci(docker): log in to Docker Hub before building image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check Docker credentials
+        run: echo "DOCKER_USER starts with $(echo $DOCKER_USER | cut -c1-4)..."
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build Docker image
         run: ./run-tests.sh --docker-build
 


### PR DESCRIPTION
Docker Hub rate-limits unauthenticated pulls to something like 100 per 6 hours per IP. GitHub-hosted runners share IP pools, causing sporadic error messages 429 "Too Many Requests" when pulling base images.

This commit improves the situation by authentication with Docker Hub using organisation credentials, avoiding shared anonymous rate limits.