### PR TITLE
Feature/s3 support

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -265,3 +265,16 @@ C4P_REANA_REL_WORKFLOW_PATH = os.getenv(
     "C4P_REANA_REL_WORKFLOW_PATH", "reana/workflows"
 )
 """Path relative to the uses home directory of the REANA workflow space on the C4P login node."""
+
+REANA_DATASTORE_ENABLED = os.getenv("REANA_DATASTORE_ENABLED") == "true"
+"""Set datastore (s3) sidecar for interactive sessions enabled or disabled"""
+
+if REANA_DATASTORE_ENABLED:
+    REANA_DATASTORE_IMAGE = os.getenv("REANA_DATASTORE_IMAGE")
+    """Optional Image for datastore (s3) sidecar for interactive sessions"""
+
+    REANA_DATASTORE_SECRET = os.getenv("REANA_DATASTORE_SECRET")
+    """Optional secret for datastore (s3) sidecar for interactive sessions"""
+else:
+    REANA_DATASTORE_IMAGE = ""
+    REANA_DATASTORE_SECRET = ""

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -210,7 +210,11 @@ class KubernetesJobManager(JobManager):
             echo "Error: Failed to mount s3 configurations within $TIMEOUT seconds. Please check you credentials"
             exit 1
             """
-            self.cmd = f"bash -c '{check_mounts_script}' && " + self.cmd + '&& curl -X POST http://localhost:5000/shutdown'
+            self.cmd = (
+                f"bash -c '{check_mounts_script}' && "
+                + self.cmd
+                + "&& curl -X POST http://localhost:5000/shutdown"
+            )
 
         self.job = {
             "kind": "Job",
@@ -246,7 +250,13 @@ class KubernetesJobManager(JobManager):
                                 "env": [],
                                 "volumeMounts": [
                                     *(
-                                        [{"name": "s3-mounts", "mountPath": "/data/s3/", "mountPropagation": "HostToContainer"}]
+                                        [
+                                            {
+                                                "name": "s3-mounts",
+                                                "mountPath": "/data/s3/",
+                                                "mountPropagation": "HostToContainer",
+                                            }
+                                        ]
                                         if REANA_DATASTORE_ENABLED and datastore_enabled
                                         else []
                                     )
@@ -260,8 +270,15 @@ class KubernetesJobManager(JobManager):
                                         "name": "datastore",
                                         "env": s3_env,
                                         "volumeMounts": [
-                                            {"name": "fuse-device", "mountPath": "/dev/fuse"},
-                                            {"name": "s3-mounts", "mountPath": "/s3-data", "mountPropagation": "Bidirectional"}
+                                            {
+                                                "name": "fuse-device",
+                                                "mountPath": "/dev/fuse",
+                                            },
+                                            {
+                                                "name": "s3-mounts",
+                                                "mountPath": "/s3-data",
+                                                "mountPropagation": "Bidirectional",
+                                            },
                                         ],
                                         "securityContext": {
                                             "runAsUser": 0,
@@ -275,15 +292,22 @@ class KubernetesJobManager(JobManager):
                                 if REANA_DATASTORE_ENABLED and datastore_enabled
                                 else []
                             ),
-                            ],
+                        ],
                         "initContainers": [],
                         "volumes": [
                             *(
                                 [
-                                    {"name": "fuse-device", "hostPath": {"path": "/dev/fuse", "type": "CharDevice"}},
-                                    {"name": "s3-mounts", "emptyDir": {}}
+                                    {
+                                        "name": "fuse-device",
+                                        "hostPath": {
+                                            "path": "/dev/fuse",
+                                            "type": "CharDevice",
+                                        },
+                                    },
+                                    {"name": "s3-mounts", "emptyDir": {}},
                                 ]
-                                if REANA_DATASTORE_ENABLED and datastore_enabled else []
+                                if REANA_DATASTORE_ENABLED and datastore_enabled
+                                else []
                             )
                         ],
                         "restartPolicy": "Never",
@@ -525,7 +549,7 @@ class KubernetesJobManager(JobManager):
         for secret_name in current_app.config["IMAGE_PULL_SECRETS"]:
             if secret_name:
                 image_pull_secrets.append({"name": secret_name})
-        if REANA_DATASTORE_ENABLED and REANA_DATASTORE_SECRET != '':
+        if REANA_DATASTORE_ENABLED and REANA_DATASTORE_SECRET != "":
             image_pull_secrets.append({"name": REANA_DATASTORE_SECRET})
 
         self.job["spec"]["template"]["spec"]["imagePullSecrets"] = image_pull_secrets

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -194,12 +194,14 @@ class KubernetesJobManager(JobManager):
             check_mounts_script = """
             #!/bin/bash
 
-            TARGET_DIR="/data/s3"
+            TARGET_FILE="/data/s3/.readiness_probe.txt"
             TIMEOUT=30
             ELAPSED=0
 
             while [ $ELAPSED -lt $TIMEOUT ]; do
-                if [ -d "$TARGET_DIR" ] && [ "$(ls -A "$TARGET_DIR")" ]; then
+                # Check if file exists AND contains the string "READY"
+                if [ -f "$TARGET_FILE" ] && grep -q "READY" "$TARGET_FILE"; then
+                    echo "Mount verified: Readiness probe detected."
                     exit 0
                 fi
 
@@ -207,7 +209,8 @@ class KubernetesJobManager(JobManager):
                 ((ELAPSED++))
             done
 
-            echo "Error: Failed to mount s3 configurations within $TIMEOUT seconds. Please check you credentials"
+            echo "Error: Failed to find 'READY' in $TARGET_FILE within $TIMEOUT seconds."
+            echo "Please check your S3 mount status and credentials."
             exit 1
             """
             self.cmd = (

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -11,6 +11,7 @@ import logging
 import os
 import traceback
 from typing import Optional
+import requests
 
 from flask import current_app
 from kubernetes import client
@@ -65,6 +66,9 @@ from reana_job_controller.config import (
     REANA_USER_ID,
     USE_KUEUE,
     KUEUE_LOCAL_QUEUE_NAME,
+    REANA_DATASTORE_ENABLED,
+    REANA_DATASTORE_SECRET,
+    REANA_DATASTORE_IMAGE,
 )
 from reana_job_controller.errors import ComputingBackendSubmissionError
 from reana_job_controller.job_manager import JobManager
@@ -175,6 +179,39 @@ class KubernetesJobManager(JobManager):
         """Execute a job in Kubernetes."""
         backend_job_id = build_unique_component_name("run-job")
 
+        user_secrets = UserSecretsStore.fetch(REANA_USER_ID)
+        all_env = user_secrets.get_env_secrets_as_k8s_spec()
+        s3_env = []
+        for secret in all_env:
+            secret_name = secret.get("name", "")
+            if secret_name.startswith("S3_TO_LOCAL_"):
+                s3_env.append(secret)
+        datastore_enabled = False
+        if s3_env:
+            datastore_enabled = True
+
+        if datastore_enabled and REANA_DATASTORE_ENABLED:
+            check_mounts_script = """
+            #!/bin/bash
+
+            TARGET_DIR="/data/s3"
+            TIMEOUT=30
+            ELAPSED=0
+
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+                if [ -d "$TARGET_DIR" ] && [ "$(ls -A "$TARGET_DIR")" ]; then
+                    exit 0
+                fi
+
+                sleep 1
+                ((ELAPSED++))
+            done
+
+            echo "Error: Failed to mount s3 configurations within $TIMEOUT seconds. Please check you credentials"
+            exit 1
+            """
+            self.cmd = f"bash -c '{check_mounts_script}' && " + self.cmd + '&& curl -X POST http://localhost:5000/shutdown'
+
         self.job = {
             "kind": "Job",
             "apiVersion": "batch/v1",
@@ -203,18 +240,53 @@ class KubernetesJobManager(JobManager):
                         "containers": [
                             {
                                 "image": self.docker_img,
+                                "name": "job",
                                 "command": ["bash", "-c"],
                                 "args": [self.cmd],
-                                "name": "job",
                                 "env": [],
-                                "volumeMounts": [],
+                                "volumeMounts": [
+                                    *(
+                                        [{"name": "s3-mounts", "mountPath": "/data/s3/", "mountPropagation": "HostToContainer"}]
+                                        if REANA_DATASTORE_ENABLED and datastore_enabled
+                                        else []
+                                    )
+                                ],
                                 "securityContext": {"allowPrivilegeEscalation": False},
-                            }
-                        ],
+                            },
+                            *(
+                                [
+                                    {
+                                        "image": REANA_DATASTORE_IMAGE,
+                                        "name": "datastore",
+                                        "env": s3_env,
+                                        "volumeMounts": [
+                                            {"name": "fuse-device", "mountPath": "/dev/fuse"},
+                                            {"name": "s3-mounts", "mountPath": "/s3-data", "mountPropagation": "Bidirectional"}
+                                        ],
+                                        "securityContext": {
+                                            "runAsUser": 0,
+                                            "allowPrivilegeEscalation": True,
+                                            "capabilities": {"add": ["SYS_ADMIN"]},
+                                            "privileged": True,
+                                        },
+                                        "imagePullPolicy": "Always",
+                                    }
+                                ]
+                                if REANA_DATASTORE_ENABLED and datastore_enabled
+                                else []
+                            ),
+                            ],
                         "initContainers": [],
-                        "volumes": [],
+                        "volumes": [
+                            *(
+                                [
+                                    {"name": "fuse-device", "hostPath": {"path": "/dev/fuse", "type": "CharDevice"}},
+                                    {"name": "s3-mounts", "emptyDir": {}}
+                                ]
+                                if REANA_DATASTORE_ENABLED and datastore_enabled else []
+                            )
+                        ],
                         "restartPolicy": "Never",
-                        # No need to wait a long time for jobs to gracefully terminate
                         "terminationGracePeriodSeconds": 5,
                         "enableServiceLinks": False,
                     },
@@ -453,6 +525,8 @@ class KubernetesJobManager(JobManager):
         for secret_name in current_app.config["IMAGE_PULL_SECRETS"]:
             if secret_name:
                 image_pull_secrets.append({"name": secret_name})
+        if REANA_DATASTORE_ENABLED and REANA_DATASTORE_SECRET != '':
+            image_pull_secrets.append({"name": REANA_DATASTORE_SECRET})
 
         self.job["spec"]["template"]["spec"]["imagePullSecrets"] = image_pull_secrets
 

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -258,33 +258,35 @@ class KubernetesJobManager(JobManager):
             datastore_enabled = True
 
         if datastore_enabled and REANA_DATASTORE_ENABLED:
-            check_mounts_script = """
-            #!/bin/bash
+            # Wrap the command to wait for datastore sidecar to mount S3 buckets
+            # Use file-based readiness check: wait for /data/s3 to exist and have content
+            script_prefix = """#!/bin/bash
 
-            TARGET_FILE="/data/s3/.readiness_probe.txt"
-            TIMEOUT=30
-            ELAPSED=0
+# Readiness check - wait for datastore sidecar to mount S3 buckets
+MOUNT_PATH="/data/s3"
+TIMEOUT=30
+ELAPSED=0
 
-            while [ $ELAPSED -lt $TIMEOUT ]; do
-                # Check if file exists AND contains the string "READY"
-                if [ -f "$TARGET_FILE" ] && grep -q "READY" "$TARGET_FILE"; then
-                    echo "Mount verified: Readiness probe detected."
-                    exit 0
-                fi
+echo "Waiting for S3 mounts to be ready..."
 
-                sleep 1
-                ((ELAPSED++))
-            done
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    if [ -d "$MOUNT_PATH" ] && [ "$(ls -A "$MOUNT_PATH" 2>/dev/null)" ]; then
+        echo "Mount verified: $MOUNT_PATH directory exists and is not empty."
+        break
+    fi
+    sleep 1
+    ((ELAPSED++))
+done
 
-            echo "Error: Failed to find 'READY' in $TARGET_FILE within $TIMEOUT seconds."
-            echo "Please check your S3 mount status and credentials."
-            exit 1
-            """
-            self.cmd = (
-                f"bash -c '{check_mounts_script}' && "
-                + self.cmd
-                + "&& curl -X POST http://localhost:5000/shutdown"
-            )
+if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "Error: S3 mounts did not become ready within $TIMEOUT seconds."
+    echo "Please check your S3 mount status and credentials."
+    exit 1
+fi
+
+"""
+            # Combine: prefix + original cmd (no shutdown hook - Kubernetes handles cleanup)
+            self.cmd = script_prefix + self.cmd
 
         self.job = {
             "kind": "Job",
@@ -339,6 +341,10 @@ class KubernetesJobManager(JobManager):
                                         "image": REANA_DATASTORE_IMAGE,
                                         "name": "datastore",
                                         "env": s3_env,
+                                        "ports": [
+                                            {"containerPort": 5000,
+                                                "name": "http", "protocol": "TCP"}
+                                        ],
                                         "volumeMounts": [
                                             {
                                                 "name": "fuse-device",
@@ -352,9 +358,48 @@ class KubernetesJobManager(JobManager):
                                         ],
                                         "securityContext": {
                                             "runAsUser": 0,
+                                            "runAsNonRoot": False,
                                             "allowPrivilegeEscalation": True,
-                                            "capabilities": {"add": ["SYS_ADMIN"]},
+                                            "capabilities": {
+                                                "add": ["SYS_ADMIN"],
+                                                "drop": ["ALL"]
+                                            },
                                             "privileged": True,
+                                            "seccompProfile": {"type": "RuntimeDefault"},
+                                        },
+                                        "readinessProbe": {
+                                            "httpGet": {
+                                                "path": "/health",
+                                                "port": 5000,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 5,
+                                            "periodSeconds": 5,
+                                            "timeoutSeconds": 2,
+                                            "successThreshold": 1,
+                                            "failureThreshold": 3
+                                        },
+                                        "livenessProbe": {
+                                            "httpGet": {
+                                                "path": "/health",
+                                                "port": 5000,
+                                                "scheme": "HTTP"
+                                            },
+                                            "initialDelaySeconds": 10,
+                                            "periodSeconds": 10,
+                                            "timeoutSeconds": 2,
+                                            "successThreshold": 1,
+                                            "failureThreshold": 3
+                                        },
+                                        "resources": {
+                                            "requests": {
+                                                "cpu": "100m",
+                                                "memory": "256Mi"
+                                            },
+                                            "limits": {
+                                                "cpu": "500m",
+                                                "memory": "512Mi"
+                                            }
                                         },
                                         "imagePullPolicy": "Always",
                                     }
@@ -374,7 +419,13 @@ class KubernetesJobManager(JobManager):
                                             "type": "CharDevice",
                                         },
                                     },
-                                    {"name": "s3-mounts", "emptyDir": {}},
+                                    {
+                                        "name": "s3-mounts",
+                                        "emptyDir": {
+                                            "medium": "Memory",
+                                            "sizeLimit": "1Gi"
+                                        }
+                                    },
                                 ]
                                 if REANA_DATASTORE_ENABLED and datastore_enabled
                                 else []
@@ -421,12 +472,16 @@ class KubernetesJobManager(JobManager):
             job_spec["volumes"].extend(volumes)
 
         if K8S_USE_SECURITY_CONTEXT:
+            pod_security_context_kwargs = {
+                "run_as_group": int(WORKFLOW_RUNTIME_USER_GID),
+                "run_as_user": int(self.kubernetes_uid),
+            }
+            # Don't set run_as_non_root at pod level if datastore is enabled
+            # (datastore container needs to run as root for FUSE)
+            if not datastore_enabled:
+                pod_security_context_kwargs["run_as_non_root"] = True
             self.job["spec"]["template"]["spec"]["securityContext"] = (
-                client.V1PodSecurityContext(
-                    run_as_group=int(WORKFLOW_RUNTIME_USER_GID),
-                    run_as_user=int(self.kubernetes_uid),
-                    run_as_non_root=True,
-                )
+                client.V1PodSecurityContext(**pod_security_context_kwargs)
             )
 
         if self.kerberos:


### PR DESCRIPTION
## Description
This PR implements the possibility to dynamically mount S3 storage via a sidecar and s3fs via /dev/fuse volume by setting the corresponding user variables mentioned in reanahub/reana-workflow-controller#671. The implementation should allow to disable this functionality via the helm charts / values.yaml file.

## Related Work
### Fixes / Implements
- Implements reanahub/reana-workflow-controller#671 (partly / only interactive sessions)
#### other issues
- Also implements variable passing for reanahub/reana-workflow-controller#504

### Dependencies
- [x] Depends on PR reanahub/reana#933 cause the helm charts have to be changed to allow controlling this feature via values.yaml file, but can be used without it, then the datastore sidecar will be turned off. 
- [x] Depends also on reanahub/reana-workflow-controller#673, but can be used without it, then the datastore sidecar will be turned off. 

## Type of Change
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] Testing was done by using `run-tests.sh`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Tests where done by manually applying changes
- [ ] New test was added for automatic testing
- [ ] Implementation is completed / ready to be merge into the master branch