### PR TITLE
feat(k8s): add TTL cleanup for finished Kubernetes jobs

### DIFF
--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -192,6 +192,18 @@ Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
 """
 
+_ttl = os.getenv("REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED")
+REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED = int(_ttl) if _ttl else None
+"""Seconds after which a finished Kubernetes Job and its pods are deleted automatically.
+
+When set, the Kubernetes TTL controller garbage-collects completed and failed Jobs
+after the specified number of seconds, preventing unbounded accumulation of stale
+objects in the cluster. When unset (the default), no automatic cleanup is performed.
+
+Please see the following URL for more details
+https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs.
+"""
+
 REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
     "REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT"
 )

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -62,6 +62,7 @@ from reana_job_controller.config import (
     REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
+    REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED,
     REANA_USER_ID,
     KUEUE_ENABLED,
     KUEUE_LOCAL_QUEUE_NAME,
@@ -241,6 +242,7 @@ class KubernetesJobManager(JobManager):
         self.add_eos_volume()
         self.add_image_pull_secrets()
         self.add_kubernetes_job_timeout()
+        self.add_kubernetes_job_ttl()
 
         if self.cvmfs_mounts != "false":
             cvmfs_repositories = ast.literal_eval(self.cvmfs_mounts)
@@ -418,6 +420,18 @@ class KubernetesJobManager(JobManager):
             self.job["spec"]["template"]["spec"][
                 "activeDeadlineSeconds"
             ] = self.kubernetes_job_timeout
+
+    def add_kubernetes_job_ttl(self):
+        """Add TTL cleanup to the job spec.
+
+        When set, the Kubernetes TTL controller automatically deletes the Job
+        and its pods after the given number of seconds once the Job finishes,
+        preventing unbounded accumulation of stale objects in the cluster.
+        """
+        if REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED is not None:
+            self.job["spec"][
+                "ttlSecondsAfterFinished"
+            ] = REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED
 
     def add_workspace_volume(self):
         """Add workspace volume to a given job spec."""

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -163,6 +163,55 @@ def test_execution_hooks():
 
 
 @pytest.mark.parametrize(
+    "ttl_seconds,expected_in_spec",
+    [
+        (3600, True),
+        (None, False),
+    ],
+)
+def test_kubernetes_job_ttl(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+    ttl_seconds,
+    expected_in_spec,
+):
+    """Test that ttlSecondsAfterFinished is set in job spec only when configured."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    monkeypatch.setattr(
+        "reana_job_controller.kubernetes_job_manager.REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED",
+        ttl_seconds,
+    )
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+    )
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            if expected_in_spec:
+                assert body["spec"]["ttlSecondsAfterFinished"] == ttl_seconds
+            else:
+                assert "ttlSecondsAfterFinished" not in body["spec"]
+
+
+@pytest.mark.parametrize(
     "k8s_phase,k8s_container_state,k8s_logs,pod_logs",
     [
         ("Pending", "ErrImagePull", "pull access denied", None),


### PR DESCRIPTION
## What this PR does

Adds support for `ttlSecondsAfterFinished` on Kubernetes Job specs, controlled by a new `REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED` environment variable.

When set, the Kubernetes TTL controller automatically garbage-collects completed and failed Jobs (and their pods) after the configured number of seconds, preventing unbounded accumulation of stale objects in the cluster.

## Motivation

Without this field, finished Jobs accumulate indefinitely. As reported in reanahub/reana#944, one production deployment observed 970 stale Jobs in the `reana` namespace, causing etcd bloat and namespace clutter.

## Changes

- `config.py`: new `REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED` config variable (integer seconds or `None`)
- `kubernetes_job_manager.py`: new `add_kubernetes_job_ttl()` method that sets `spec.ttlSecondsAfterFinished` on the Job; called from `execute()` alongside the existing `add_kubernetes_job_timeout()`
- `tests/test_job_manager.py`: parametrised test covering both the configured case (field is present with correct value) and the unconfigured case (field is absent)

## Backwards compatibility

The variable defaults to `None`, so the field is **never added** unless the operator explicitly sets the env var. Existing deployments are completely unaffected until they opt in.

## Enabling the feature in a deployment

Operators can enable TTL cleanup by adding to their Helm `values.yaml`:

```yaml
components:
  reana_job_controller:
    environment:
      REANA_KUBERNETES_JOBS_TTL_SECONDS_AFTER_FINISHED: "604800"  # 7 days
```

`reana-workflow-controller` reads `components.reana_job_controller.environment` and injects those key-value pairs into the job-controller sidecar on every batch pod, so no additional changes are needed for this path.

A separate follow-up (touching `reana-workflow-controller` config + `workflow_run_manager.py` and the `reana` Helm chart template) would expose this as a first-class `kubernetes_jobs_ttl_seconds_after_finished` key at the top level of `values.yaml`, consistent with `kubernetes_jobs_timeout_limit` and similar settings — improving operator discoverability without being a prerequisite for the feature to work.

Closes reanahub/reana#944