### PR TITLE
feat(env): expose workflow name and run number to job pods

### DIFF
--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -150,4 +150,13 @@ class JobManager:
         env_vars[prefix + "_WORKSPACE"] = self.workflow_workspace
         env_vars[prefix + "_WORKFLOW_UUID"] = str(self.workflow_uuid)
         env_vars["DASK_SCHEDULER_URI"] = DASK_SCHEDULER_URI
+        if self.workflow_uuid:
+            workflow = (
+                Session.query(Workflow)
+                .filter_by(id_=self.workflow_uuid)
+                .one_or_none()
+            )
+            if workflow:
+                env_vars[prefix + "_WORKFLOW_NAME"] = workflow.name
+                env_vars[prefix + "_WORKFLOW_RUN_NUMBER"] = workflow.run_number
         return env_vars

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -82,19 +82,33 @@ def test_execute_kubernetes_job(
             command = containers[0]["args"]
             assert {"name": env_var_key, "value": env_var_value} in env_vars
             assert image == expected_image
+            env_var_names = {e["name"] for e in env_vars}
+            assert "REANA_WORKFLOW_NAME" in env_var_names
+            assert "REANA_WORKFLOW_RUN_NUMBER" in env_var_names
+            assert {
+                "name": "REANA_WORKFLOW_NAME",
+                "value": sample_serial_workflow_in_db.name,
+            } in env_vars
+            assert {
+                "name": "REANA_WORKFLOW_RUN_NUMBER",
+                "value": sample_serial_workflow_in_db.run_number,
+            } in env_vars
             if kerberos:
                 assert len(containers) == 2  # main job + sidecar
                 assert len(init_containers) == 1
                 assert init_containers[0]["name"] == KRB5_INIT_CONTAINER_NAME
-                assert len(env_vars) == 7  # KRB5CCNAME is added
+                # custom env + REANA_WORKSPACE + REANA_WORKFLOW_UUID + DASK_SCHEDULER_URI
+                # + REANA_WORKFLOW_NAME + REANA_WORKFLOW_RUN_NUMBER + two secrets + KRB5CCNAME
+                assert len(env_vars) == 9
                 assert "trap" in command[0] and expected_command in command[0]
                 assert "kinit -R" in containers[1]["args"][0]
                 assert containers[1]["name"] == KRB5_RENEW_CONTAINER_NAME
             else:
                 assert len(containers) == 1
                 assert len(init_containers) == 0
-                # custom env + REANA_WORKSPACE + REANA_WORKFLOW_UUID + DASK_SCHEDULER_URI + two secrets
-                assert len(env_vars) == 6
+                # custom env + REANA_WORKSPACE + REANA_WORKFLOW_UUID + DASK_SCHEDULER_URI
+                # + REANA_WORKFLOW_NAME + REANA_WORKFLOW_RUN_NUMBER + two secrets
+                assert len(env_vars) == 8
                 assert command == [expected_command]
 
 


### PR DESCRIPTION
## What this PR does

Adds \`REANA_WORKFLOW_NAME\` and \`REANA_WORKFLOW_RUN_NUMBER\` to the set of environment variables injected into every job pod, alongside the existing \`REANA_WORKSPACE\` and \`REANA_WORKFLOW_UUID\`.

## Implementation

Both values are fetched from the database in \`_extend_env_vars()\` using the \`workflow_uuid\` already available at job creation time — no changes required in \`reana-commons\` or the workflow engines.

\`REANA_WORKFLOW_RUN_NUMBER\` uses the existing \`Workflow.run_number\` property, which returns \`"major"\` or \`"major.minor"\` for restarted runs.

## Why this is useful

Job steps can now identify themselves at runtime without having to parse the workspace path or query external services — useful for logging, debugging, and reading workflow context from within Snakemake rule shell commands.

## Scope

This PR addresses the first part of the linked issue: exposing the vars to **job pods**. The second part — making these vars available in the job-controller sidecar container itself (so they can be read by the Snakemake engine during workflow file parsing, before any jobs are submitted) — requires the workflow-controller to inject them when creating the batch pod and is left for a follow-up.

## Changes

- \`job_manager.py\`: query the DB for the workflow in \`_extend_env_vars()\` and inject \`REANA_WORKFLOW_NAME\` and \`REANA_WORKFLOW_RUN_NUMBER\` when the workflow exists
- \`tests/test_job_manager.py\`: assert the two new vars are present with correct values in the submitted job spec; update env var count comments

Related to reanahub/reana-job-controller#454