### PR TITLE
build(python): upgrade to Flask 3.x

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,6 +1,7 @@
 {
   "definitions": {
     "Job": {
+      "additionalProperties": false,
       "properties": {
         "cmd": {
           "type": "string"
@@ -16,11 +17,9 @@
           "type": "string"
         },
         "max_restart_count": {
-          "format": "int32",
           "type": "integer"
         },
         "restart_count": {
-          "format": "int32",
           "type": "integer"
         },
         "status": {
@@ -38,6 +37,7 @@
       "type": "object"
     },
     "JobRequest": {
+      "additionalProperties": false,
       "properties": {
         "c4p_additional_requirements": {
           "type": "string"
@@ -63,6 +63,7 @@
           "type": "string"
         },
         "env_vars": {
+          "additionalProperties": {},
           "default": {},
           "type": "object"
         },
@@ -85,7 +86,6 @@
           "type": "string"
         },
         "kubernetes_job_timeout": {
-          "format": "int32",
           "type": "integer"
         },
         "kubernetes_memory_limit": {
@@ -95,7 +95,6 @@
           "type": "string"
         },
         "kubernetes_uid": {
-          "format": "int32",
           "type": "integer"
         },
         "prettified_cmd": {

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -13,6 +13,7 @@ import json
 import logging
 import threading
 
+import marshmallow
 from flask import Blueprint, current_app, jsonify, request
 from sqlalchemy.exc import OperationalError
 from reana_commons.errors import (
@@ -267,9 +268,10 @@ def create_job():  # noqa
         return jsonify({"message": "Empty request"}), 400
 
     # Validate and deserialize input
-    job_request, errors = job_request_schema.load(json_data)
-    if errors:
-        return jsonify({"message": errors}), 400
+    try:
+        job_request = job_request_schema.load(json_data)
+    except marshmallow.ValidationError as e:
+        return jsonify({"message": e.messages}), 400
 
     compute_backend = job_request.get(
         "compute_backend", current_app.config["DEFAULT_COMPUTE_BACKEND"]

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -27,7 +27,7 @@ class Job(Schema):
     max_restart_count = fields.Int(required=True)
     restart_count = fields.Int(required=True)
     status = fields.Str(required=True)
-    cvmfs_mounts = fields.String(missing="")
+    cvmfs_mounts = fields.String(load_default="")
 
 
 class JobRequest(Schema):
@@ -37,13 +37,16 @@ class JobRequest(Schema):
     workflow_workspace = fields.Str(required=True)
     workflow_uuid = fields.Str(required=True)
     cmd = fields.Function(
-        missing="", deserialize=deserialise_job_command, type="string"
+        serialize=lambda obj: "",
+        deserialize=deserialise_job_command,
+        load_default="",
+        metadata={"type": "string"},
     )
-    prettified_cmd = fields.Str(missing="")
+    prettified_cmd = fields.Str(load_default="")
     docker_img = fields.Str(required=True)
-    cvmfs_mounts = fields.String(missing="")
-    env_vars = fields.Dict(missing={})
-    shared_file_system = fields.Bool(missing=True)
+    cvmfs_mounts = fields.String(load_default="")
+    env_vars = fields.Dict(load_default={})
+    shared_file_system = fields.Bool(load_default=True)
     compute_backend = fields.Str(required=False)
     kerberos = fields.Bool(required=False)
     voms_proxy = fields.Bool(required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,83 +6,83 @@
 #
 alembic==1.18.4           # via reana-db
 amqp==5.3.1               # via kombu
-apispec[yaml]==3.3.2      # via apispec-webframeworks, reana-job-controller (setup.py)
-apispec-webframeworks==0.5.2  # via reana-job-controller (setup.py)
+apispec[yaml]==6.10.0     # via apispec-webframeworks, reana-job-controller (setup.py)
+apispec-webframeworks==1.2.0  # via reana-job-controller (setup.py)
 appdirs==1.4.4            # via fs
 arrow==1.4.0              # via isoduration
 attrs==26.1.0             # via jsonschema, referencing
 bcrypt==5.0.0             # via paramiko
+blinker==1.9.0            # via flask
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-certifi==2026.2.25        # via kubernetes, requests
+certifi==2026.4.22        # via kubernetes, requests
 cffi==2.0.0               # via cryptography, pynacl
-charset-normalizer==3.4.6  # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.3.1              # via flask, reana-commons
-cryptography==46.0.6      # via google-auth, paramiko, sqlalchemy-utils
+click==8.3.3              # via flask, reana-commons
+cryptography==47.0.0      # via paramiko, sqlalchemy-utils
 decorator==5.2.1          # via gssapi
-flask==2.2.5              # via reana-job-controller (setup.py)
+durationpy==0.10          # via kubernetes
+flask==3.1.3              # via reana-job-controller (setup.py)
 fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons, reana-job-controller (setup.py)
 gherkin-official==39.0.0  # via reana-commons
-google-auth==2.49.1       # via kubernetes
-greenlet==3.3.2           # via sqlalchemy
+greenlet==3.5.0           # via sqlalchemy
 gssapi==1.11.1            # via paramiko
-idna==3.11                # via jsonschema, requests
-importlib-resources==6.5.2  # via swagger-spec-validator
-invoke==2.2.1             # via paramiko
+idna==3.13                # via jsonschema, requests
+importlib-resources==7.1.0  # via swagger-spec-validator
+invoke==3.0.3             # via paramiko
 isoduration==20.11.0      # via jsonschema
 itsdangerous==2.2.0       # via flask
-jinja2==3.0.3             # via flask, reana-job-controller (setup.py)
+jinja2==3.1.6             # via flask
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
 jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
 jsonschema-specifications==2025.9.1  # via jsonschema
 kombu==5.6.2              # via reana-commons
-kubernetes==26.1.0        # via reana-commons
-mako==1.3.10              # via alembic
-markupsafe==3.0.3         # via jinja2, mako, werkzeug
-marshmallow==2.21.0       # via reana-job-controller (setup.py)
+kubernetes==35.0.0        # via reana-commons
+mako==1.3.11              # via alembic
+markupsafe==3.0.3         # via flask, jinja2, mako, werkzeug
+marshmallow==3.26.2       # via reana-job-controller (setup.py)
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core
 msgpack-python==0.5.6     # via bravado
 oauthlib==3.3.1           # via requests-oauthlib
-packaging==26.0           # via kombu
+packaging==26.2           # via apispec, kombu, marshmallow
 paramiko[gssapi]==4.0.0   # via reana-job-controller (setup.py)
 parse==1.21.1             # via reana-commons
-psycopg2-binary==2.9.11   # via reana-db
-pyasn1==0.6.3             # via paramiko, pyasn1-modules
-pyasn1-modules==0.4.2     # via google-auth
+psycopg2-binary==2.9.12   # via reana-db
+pyasn1==0.6.3             # via paramiko
 pycparser==3.0            # via cffi
 pynacl==1.6.2             # via paramiko
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a14  # via reana-db, reana-job-controller (setup.py)
-reana-db==0.95.0a6        # via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.95.0a15  # via reana-db, reana-job-controller (setup.py)
+reana-db==0.95.0a7        # via reana-job-controller (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.0          # via bravado, bravado-core, kubernetes, requests-oauthlib
+requests==2.33.1          # via bravado, bravado-core, kubernetes, requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes
 retrying==1.4.2           # via reana-job-controller (setup.py)
 rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
 rpds-py==0.30.0           # via jsonschema, referencing
-simplejson==3.20.2        # via bravado, bravado-core
+simplejson==4.1.1         # via bravado, bravado-core
 six==1.17.0               # via bravado, bravado-core, fs, kubernetes, mock, python-dateutil, rfc3339-validator
-sqlalchemy==1.4.54        # via alembic, reana-db, sqlalchemy-utils
-sqlalchemy-utils[encrypted]==0.42.1  # via reana-db, sqlalchemy-utils
+sqlalchemy==2.0.49        # via alembic, reana-db, sqlalchemy-utils
+sqlalchemy-utils[encrypted]==0.41.2  # via reana-db, sqlalchemy-utils
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
+typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, sqlalchemy, swagger-spec-validator
+tzdata==2026.2            # via arrow, kombu
 uri-template==1.3.0       # via jsonschema
 urllib3==2.6.3            # via kubernetes, requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema
 websocket-client==1.9.0   # via kubernetes
-werkzeug==2.2.3           # via flask, reana-commons, reana-job-controller (setup.py)
+werkzeug==3.1.8           # via flask, reana-commons, reana-job-controller (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -34,7 +34,7 @@ clean_old_db_container() {
     OLD="$(docker ps --all --quiet --filter=name=postgres__reana-job-controller)"
     if [ -n "$OLD" ]; then
         echo '==> [INFO] Cleaning old DB container...'
-        docker stop postgres__reana-job-controller
+        docker rm -f postgres__reana-job-controller >/dev/null 2>&1 || true
     fi
 }
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -37,7 +37,7 @@ extras_require = {
         "htcondor>=9.0.17",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a4,<0.96.0",
+        "pytest-reana>=0.95.0a9,<0.96.0",
     ],
     "ssh": ["paramiko[gssapi]>=3.2.0"],
     "mytoken": [
@@ -56,16 +56,14 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    # apispec>=4.0 drops support for marshmallow<3
-    "apispec[yaml]>=3.0,<4.0",
+    "apispec[yaml]>=3.0",
     "apispec-webframeworks",
-    "Flask>=2.1.1,<2.3.0",  # same upper pin as invenio-base/reana-server
-    "Werkzeug>=2.1.0,<2.3.0",  # same upper pin as invenio-base
-    "jinja2<3.1.0",
+    "Flask>=3.0.0,<4.0.0",
+    "Werkzeug>=3.0.0",
     "fs>=2.0",
-    "marshmallow>2.13.0,<3.0.0",  # same upper pin as reana-server
-    "reana-commons[kubernetes]>=0.95.0a14,<0.96.0",
-    "reana-db>=0.95.0a6,<0.96.0",
+    "marshmallow>=3.5.0,<4.0.0",
+    "reana-commons[kubernetes]>=0.95.0a15,<0.96.0",
+    "reana-db>=0.95.0a7,<0.96.0",
     "retrying>=1.3.3",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def mocked_job():
 def job_spec():
     """Job spec dict."""
     job_spec = {
-        "experiment": "experiment",
         "docker_img": "image",
         "cmd": "cmd",
         "prettified_cmd": "prettified_cmd",


### PR DESCRIPTION
Upgrade Flask from `<2.3.0` to `>=3.0.0` and Werkzeug from `<2.3.0` to `>=3.0.0`, in line with the Invenio package upgrade in reana-server. Bump marshmallow from `<3.0.0` to `>=3.5.0,<4.0.0` since the new Invenio stack requires marshmallow 3. Remove the obsolete `jinja2<3.1.0` upper pin and the `apispec<4.0` upper pin (the latter only existed to support marshmallow 2).

Adapt the job request schema to marshmallow 3 by replacing the deprecated `missing=` parameter with `load_default=` on every field. The `cmd` field is also updated to provide both `serialize` and `deserialize` callables (the old
`fields.Function(deserialize=...)` shape would set `serialize_func=None` and crash when apispec tried to serialize the field default), and the `type="string"` keyword is moved into `metadata`.

Adjust the job creation handler to the marshmallow 3 calling convention: `schema.load()` no longer returns a `(data, errors)` tuple, so wrap the call in a `try/except ValidationError` block instead.

Closes reanahub/reana-server#770.