### PR TITLE
refactor(pytest): drop pytest-reana for reana-commons[tests]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .pytest_cache
 CHANGELOG.md
 docs/openapi.json
+modules

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_job_controller --cov-report=term-missing  --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_job_controller --cov-report=term-missing  --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,8 +60,8 @@ pynacl==1.6.2             # via paramiko
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a15  # via reana-db, reana-job-controller (setup.py)
-reana-db==0.95.0a7        # via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.95.0a17	# via reana-db, reana-job-controller (setup.py)
+reana-db==0.95.0a9	# via reana-job-controller (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
 requests==2.33.1          # via bravado, bravado-core, kubernetes, requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ amqp==5.3.1               # via kombu
 apispec[yaml]==6.10.0     # via apispec-webframeworks, reana-job-controller (setup.py)
 apispec-webframeworks==1.2.0  # via reana-job-controller (setup.py)
 appdirs==1.4.4            # via fs
-arrow==1.4.0              # via isoduration
-attrs==26.1.0             # via jsonschema, referencing
+attrs==26.1.0             # via jsonschema
 bcrypt==5.0.0             # via paramiko
 blinker==1.9.0            # via flask
 bracex==2.6               # via wcmatch
@@ -21,28 +20,23 @@ cffi==2.0.0               # via cryptography, pynacl
 charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
 click==8.3.3              # via flask, reana-commons
-cryptography==47.0.0      # via paramiko, sqlalchemy-utils
-decorator==5.2.1          # via gssapi
+cryptography==48.0.0      # via paramiko, sqlalchemy-utils
 durationpy==0.10          # via kubernetes
 flask==3.1.3              # via reana-job-controller (setup.py)
-fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons, reana-job-controller (setup.py)
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 greenlet==3.5.0           # via sqlalchemy
-gssapi==1.11.1            # via paramiko
-idna==3.13                # via jsonschema, requests
+idna==3.14                # via jsonschema, requests
 importlib-resources==7.1.0  # via swagger-spec-validator
 invoke==3.0.3             # via paramiko
-isoduration==20.11.0      # via jsonschema
 itsdangerous==2.2.0       # via flask
 jinja2==3.1.6             # via flask
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
-jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
-jsonschema-specifications==2025.9.1  # via jsonschema
+jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.6.2              # via reana-commons
 kubernetes==35.0.0        # via reana-commons
-mako==1.3.11              # via alembic
+mako==1.3.12              # via alembic
 markupsafe==3.0.3         # via flask, jinja2, mako, werkzeug
 marshmallow==3.26.2       # via reana-job-controller (setup.py)
 mock==3.0.5               # via reana-commons
@@ -51,33 +45,30 @@ msgpack==1.1.2            # via bravado-core
 msgpack-python==0.5.6     # via bravado
 oauthlib==3.3.1           # via requests-oauthlib
 packaging==26.2           # via apispec, kombu, marshmallow
-paramiko[gssapi]==4.0.0   # via reana-job-controller (setup.py)
-parse==1.21.1             # via reana-commons
+paramiko[gssapi]==5.0.0   # via reana-job-controller (setup.py)
+parse==1.22.0             # via reana-commons
 psycopg2-binary==2.9.12   # via reana-db
-pyasn1==0.6.3             # via paramiko
 pycparser==3.0            # via cffi
 pynacl==1.6.2             # via paramiko
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
-pytz==2026.1.post1        # via bravado-core
+pyrsistent==0.20.0        # via jsonschema
+python-dateutil==2.9.0.post0  # via bravado, bravado-core, kubernetes
+pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a17	# via reana-db, reana-job-controller (setup.py)
-reana-db==0.95.0a9	# via reana-job-controller (setup.py)
-referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.1          # via bravado, bravado-core, kubernetes, requests-oauthlib
+reana-commons[kubernetes]==0.95.0a17  # via reana-db, reana-job-controller (setup.py)
+reana-db==0.95.0a9        # via reana-job-controller (setup.py)
+requests==2.34.0          # via bravado, bravado-core, kubernetes, requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes
 retrying==1.4.2           # via reana-job-controller (setup.py)
-rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
-rpds-py==0.30.0           # via jsonschema, referencing
 simplejson==4.1.1         # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, kubernetes, mock, python-dateutil, rfc3339-validator
+six==1.17.0               # via bravado, bravado-core, fs, jsonschema, kubernetes, mock, python-dateutil
 sqlalchemy==2.0.49        # via alembic, reana-db, sqlalchemy-utils
 sqlalchemy-utils[encrypted]==0.41.2  # via reana-db, sqlalchemy-utils
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, sqlalchemy, swagger-spec-validator
-tzdata==2026.2            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via kubernetes, requests
+typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, sqlalchemy, swagger-spec-validator
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via kubernetes, requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ set -o nounset
 
 COMPONENT_NAME=reana-job-controller
 DOCKER_IMAGE_NAME=docker.io/reanahub/$COMPONENT_NAME
-PLATFORM="$(python -c 'import platform; print(platform.system())')"
+PLATFORM="$(python3 -c 'import platform; print(platform.system())')"
 
 # Verify that db container is running before continuing
 _check_ready() {
@@ -179,26 +179,42 @@ all() {
 }
 
 all_darwin() {
-    # Tests are run inside the docker container because there is
-    # no HTCondor Python package for MacOS
-    lint_hadolint
+    # Python tests and documentation checks are run inside the Docker
+    # container because there is no HTCondor Python package for MacOS.
     docker_build
+    format_black
+    format_prettier
+    format_shfmt
+    lint_commitlint
+    lint_flake8
+    lint_hadolint
+    lint_jsonlint
+    lint_manifest
+    lint_markdownlint
+    lint_pydocstyle
+    lint_shellcheck
+    lint_yamllint
     clean_old_db_container
     start_db_container
     RUN_TESTS_INSIDE_DOCKER="
     cd $COMPONENT_NAME &&
-    apt update && apt-get -y install libkrb5-dev git shellcheck  &&
+    apt update && apt-get -y install libkrb5-dev git &&
+    pip install --upgrade --ignore-installed pip 'setuptools<81' py &&
     pip install -r requirements.txt &&
     pip install -e .[all] && # Install test dependencies
-    pip install black &&
-    pip install flake8 &&
-    pip install pydocstyle &&
-    pip install check-manifest &&
     export REANA_SQLALCHEMY_DATABASE_URI=$REANA_SQLALCHEMY_DATABASE_URI &&
-    ./run-tests.sh --all &&
+    ./run-tests.sh --docs-openapi &&
+    ./run-tests.sh --docs-sphinx &&
     pytest"
     docker run -v "$(pwd)"/..:/code -ti $DOCKER_IMAGE_NAME bash -c "eval $RUN_TESTS_INSIDE_DOCKER"
     stop_db_container
+}
+
+run_all() {
+    case $PLATFORM in
+    Darwin*) all_darwin ;;
+    *) all ;;
+    esac
 }
 
 help() {
@@ -225,18 +241,13 @@ help() {
 }
 
 if [ $# -eq 0 ]; then
-    case $PLATFORM in
-    Darwin*) all_darwin ;;
-    *)
-        all
-        ;;
-    esac
+    run_all
     exit 0
 fi
 
 arg="$1"
 case $arg in
---all) all ;;
+--all) run_all ;;
 --help) help ;;
 --docker-build) docker_build ;;
 --docs-openapi) docs_openapi ;;

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ extras_require = {
         "htcondor>=9.0.17",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a9,<0.96.0",
+        "reana-commons[kubernetes,tests]>=0.95.0a17,<0.96.0",
+        "reana-db[tests]>=0.95.0a9,<0.96.0",
     ],
     "ssh": ["paramiko[gssapi]>=3.2.0"],
     "mytoken": [
@@ -62,8 +63,8 @@ install_requires = [
     "Werkzeug>=3.0.0",
     "fs>=2.0",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes]>=0.95.0a15,<0.96.0",
-    "reana-db>=0.95.0a7,<0.96.0",
+    "reana-commons[kubernetes]>=0.95.0a17,<0.96.0",
+    "reana-db>=0.95.0a9,<0.96.0",
     "retrying>=1.3.3",
 ]
 


### PR DESCRIPTION
Replace pytest-reana in extras_require[tests] with the new
reana-commons[kubernetes,tests] and reana-db[tests] extras. The
fixtures used by the test suite (tmp_shared_volume_path,
sample_serial_workflow_in_db, sample_workflow_workspace, user0,
kerberos_user_secrets, empty_user_secrets,
corev1_api_client_with_user_secrets) are auto-loaded via the pytest11
entry points the two libraries now register, so tests/conftest.py
needs no change.

Closes https://github.com/reanahub/pytest-reana/issues/156