### PR TITLE
build(docker): use uWSGI server instead of Flask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,6 +29,9 @@ RUN apt-get update -y && \
       krb5-user \
       libauthen-krb5-simple-perl \
       libkrb5-dev \
+      libpcre3 \
+      libpcre3-dev \
+      libpython3.12 \
       openssh-client \
       # matches version in setup.py/requirements.in
       python3-gssapi=1.8.2-1ubuntu1 \
@@ -39,7 +42,8 @@ RUN apt-get update -y && \
     pip install --no-cache-dir --upgrade 'setuptools<81' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
-      gcc && \
+      gcc \
+      libpcre3-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -137,7 +141,7 @@ RUN userdel -r ubuntu
 # Expose ports to clients
 EXPOSE 5000
 
-# Run server
+# Run server (in a full REANA deployment, this is overridden at runtime by reana-workflow-controller)
 CMD ["flask", "run", "-h", "0.0.0.0"]
 
 # Set image labels

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ swagger-spec-validator==3.0.4  # via bravado-core
 typing-extensions==4.15.0  # via aiohttp, aiosignal, alembic, bravado, gherkin-official, sqlalchemy, swagger-spec-validator
 tzdata==2026.2            # via kombu
 urllib3==2.7.0            # via kubernetes, requests
+uwsgi==2.0.31             # via reana-job-controller (setup.py)
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ install_requires = [
     "apispec[yaml]>=3.0",
     "apispec-webframeworks",
     "Flask>=3.0.0,<4.0.0",
+    "uWSGI>=2.0.31",
     "Werkzeug>=3.0.0",
     "fs>=2.0",
     "marshmallow>=3.5.0,<4.0.0",


### PR DESCRIPTION
Still allows debugging with Flask if the
FLASK_DEBUG env variable is set.

Closes reanahub/reana#952