### PR TITLE
feat(config): allow customising minimum Kubernetes job user ID

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -283,6 +283,17 @@
           "400": {
             "description": "Request failed. The incoming data specification seems malformed."
           },
+          "403": {
+            "description": "Request failed. The job submission was refused, e.g. because a requested resource (CPU, memory, UID) violates the cluster-configured limits.",
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
           "500": {
             "description": "Request failed. Internal controller error. The job could probably not have been allocated."
           }

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -199,6 +199,18 @@ REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
 
 Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
+"""
+
+REANA_KUBERNETES_JOBS_MIN_USER_UID = int(
+    os.getenv("REANA_KUBERNETES_JOBS_MIN_USER_UID", 100)
+)
+"""Minimum accepted user runtime container UID that users can assign to their job
+containers via ``kubernetes_uid`` in ``reana.yaml``. Jobs requesting a smaller
+UID are refused at submission time with a clear error message.
+
+The default value of 100 blocks the root user (UID 0) and the statically
+reserved 1-99 system-user range. Cluster administrators can raise this minimum
+to align with Pod Security Standards "restricted" expectations.
 """
 
 SLURM_HEADNODE_HOSTNAME = os.getenv("SLURM_HOSTNAME", "hpc-batch.cern.ch")

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -32,6 +32,7 @@ from reana_commons.errors import (
     REANAKubernetesCPULimitExceeded,
     REANAKubernetesWrongCPUFormat,
     REANAKubernetesRequestExceedsLimit,
+    REANAKubernetesUIDBelowMinimum,
 )
 from reana_commons.job_utils import (
     validate_kubernetes_memory,
@@ -62,6 +63,7 @@ from reana_job_controller.config import (
     REANA_KUBERNETES_JOBS_MAX_USER_CPU_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
+    REANA_KUBERNETES_JOBS_MIN_USER_UID,
     REANA_USER_ID,
     KUEUE_ENABLED,
     KUEUE_LOCAL_QUEUE_NAME,
@@ -123,7 +125,7 @@ class KubernetesJobManager(JobManager):
         :type job_name: str
         :param kerberos: Decides if kerberos should be provided for job.
         :type kerberos: bool
-        :param kubernetes_uid: User ID for job container.
+        :param kubernetes_uid: UID for job container.
         :type kubernetes_uid: int
         :param kubernetes_memory_limit: Memory limit for job container.
         :type kubernetes_memory_limit: str
@@ -733,11 +735,22 @@ class KubernetesJobManager(JobManager):
         )
 
     def set_user_id(self, kubernetes_uid):
-        """Set user id for job pods. UIDs < 100 are refused for security."""
-        if kubernetes_uid and kubernetes_uid >= 100:
-            self.kubernetes_uid = kubernetes_uid
-        else:
+        """Set UID for job pods.
+
+        UIDs below the cluster-configured minimum
+        (``REANA_KUBERNETES_JOBS_MIN_USER_UID``) are refused for security.
+        """
+        if kubernetes_uid is None:
             self.kubernetes_uid = WORKFLOW_RUNTIME_USER_UID
+            return
+        if kubernetes_uid < REANA_KUBERNETES_JOBS_MIN_USER_UID:
+            msg = (
+                f'The "kubernetes_uid" requested ({kubernetes_uid}) is below '
+                f"the cluster-configured minimum "
+                f"({REANA_KUBERNETES_JOBS_MIN_USER_UID})."
+            )
+            raise REANAKubernetesUIDBelowMinimum(msg)
+        self.kubernetes_uid = kubernetes_uid
 
     def set_cpu_request(self, kubernetes_cpu_request):
         """Set CPU request for job pods. Validate if provided format is correct."""

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022, 2023, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,6 +21,7 @@ from reana_commons.errors import (
     REANAKubernetesWrongMemoryFormat,
     REANAKubernetesCPULimitExceeded,
     REANAKubernetesWrongCPUFormat,
+    REANAKubernetesUIDBelowMinimum,
 )
 
 from reana_db.models import JobStatus
@@ -258,6 +259,16 @@ def create_job():  # noqa
         400:
           description: >-
             Request failed. The incoming data specification seems malformed.
+        403:
+          description: >-
+            Request failed. The job submission was refused, e.g. because a
+            requested resource (CPU, memory, UID) violates the
+            cluster-configured limits.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
         500:
           description: >-
             Request failed. Internal controller error. The job could probably
@@ -302,6 +313,8 @@ def create_job():  # noqa
             return jsonify({"message": e.message}), 403
         except REANAKubernetesWrongMemoryFormat as e:
             return jsonify({"message": e.message}), 400
+        except REANAKubernetesUIDBelowMinimum as e:
+            return jsonify({"message": e.message}), 403
     if not job_creation_condition.start_creation():
         return jsonify({"message": "Cannot create new jobs, shutting down"}), 400
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,8 @@ pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.9.0.post0  # via bravado, bravado-core, kubernetes
 pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via apispec, bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a17  # via reana-db, reana-job-controller (setup.py)
-reana-db==0.95.0a9        # via reana-job-controller (setup.py)
+reana-commons[kubernetes]==0.95.0a18	# via reana-db, reana-job-controller (setup.py)
+reana-db==0.95.0a10	# via reana-job-controller (setup.py)
 requests==2.34.0          # via bravado, bravado-core, kubernetes, requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes
 retrying==1.4.2           # via reana-job-controller (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ extras_require = {
         "htcondor>=9.0.17",
     ],
     "tests": [
-        "reana-commons[kubernetes,tests]>=0.95.0a17,<0.96.0",
-        "reana-db[tests]>=0.95.0a9,<0.96.0",
+        "reana-commons[kubernetes,tests]>=0.95.0a18,<0.96.0",
+        "reana-db[tests]>=0.95.0a10,<0.96.0",
     ],
     "ssh": ["paramiko[gssapi]>=3.2.0"],
     "mytoken": [
@@ -63,8 +63,8 @@ install_requires = [
     "Werkzeug>=3.0.0",
     "fs>=2.0",
     "marshmallow>=3.5.0,<4.0.0",
-    "reana-commons[kubernetes]>=0.95.0a17,<0.96.0",
-    "reana-db>=0.95.0a9,<0.96.0",
+    "reana-commons[kubernetes]>=0.95.0a18,<0.96.0",
+    "reana-db>=0.95.0a10,<0.96.0",
     "retrying>=1.3.3",
 ]
 

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,11 +14,16 @@ import uuid
 import mock
 import pytest
 from reana_db.models import Job, JobStatus
-from reana_commons.config import KRB5_INIT_CONTAINER_NAME, KRB5_RENEW_CONTAINER_NAME
+from reana_commons.config import (
+    KRB5_INIT_CONTAINER_NAME,
+    KRB5_RENEW_CONTAINER_NAME,
+    WORKFLOW_RUNTIME_USER_UID,
+)
 from reana_commons.errors import (
     REANAKubernetesCPULimitExceeded,
     REANAKubernetesWrongCPUFormat,
     REANAKubernetesMemoryLimitExceeded,
+    REANAKubernetesUIDBelowMinimum,
     REANAKubernetesWrongMemoryFormat,
 )
 from reana_job_controller.job_manager import JobManager
@@ -332,3 +337,36 @@ def test_set_memory_limit(
     else:
         job_manager.set_memory_limit(memory_limit)
         assert job_manager.kubernetes_memory_limit == expected_value
+
+
+@pytest.mark.parametrize(
+    "kubernetes_uid,min_user_uid,should_raise,expected_value",
+    [
+        (1500, 100, False, 1500),  # UID well above minimum accepted as-is.
+        (100, 100, False, 100),  # UID equal to minimum accepted.
+        (1000, 1000, False, 1000),  # Accepted under admin-raised minimum.
+        (None, 100, False, WORKFLOW_RUNTIME_USER_UID),  # No UID: default.
+        (50, 100, True, None),  # Below default minimum: refused.
+        (500, 1000, True, None),  # Below admin-raised minimum: refused.
+        (0, 100, True, None),  # Root refused.
+    ],
+)
+def test_set_user_id(
+    app, monkeypatch, kubernetes_uid, min_user_uid, should_raise, expected_value
+):
+    """Test that the configurable UID minimum is honoured."""
+    monkeypatch.setattr(
+        "reana_job_controller.kubernetes_job_manager.REANA_KUBERNETES_JOBS_MIN_USER_UID",
+        min_user_uid,
+    )
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+    )
+    if should_raise:
+        with pytest.raises(REANAKubernetesUIDBelowMinimum):
+            job_manager.set_user_id(kubernetes_uid)
+    else:
+        job_manager.set_user_id(kubernetes_uid)
+        assert job_manager.kubernetes_uid == expected_value


### PR DESCRIPTION
REANA already refuses runtime container user IDs below 100 in `KubernetesJobManager.set_user_id`, blocking root and the statically reserved system-user range. This commit makes that lower bound configurable via the `REANA_KUBERNETES_JOBS_MIN_USER_UID` environment variable (default 100) so that cluster administrators can customise their deployments and, if desired, set even higher minimum runtime container user ID limits.

Jobs requesting a `kubernetes_uid` below the configured minimum are now refused at submission time with a clear error naming both the rejected UID and the configured minimum, mirroring the existing `kubernetes_memory_limit` / `kubernetes_cpu_limit` validation patterns that users are already familiar with. Previously such workflows were silently substituted with the cluster default UID at runtime, often surfacing as opaque permission errors inside user containers.

Closes reanahub/reana#951