### PR TITLE
feat(kubernetes): set explicit runAsNonRoot on job pods

### DIFF
--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -252,7 +252,9 @@ class KubernetesJobManager(JobManager):
 
         self.job["spec"]["template"]["spec"]["securityContext"] = (
             client.V1PodSecurityContext(
-                run_as_group=WORKFLOW_RUNTIME_USER_GID, run_as_user=self.kubernetes_uid
+                run_as_group=WORKFLOW_RUNTIME_USER_GID,
+                run_as_user=self.kubernetes_uid,
+                run_as_non_root=True,
             )
         )
 


### PR DESCRIPTION
Set `runAsNonRoot: true` on the job pod's `V1PodSecurityContext` so Kubernetes refuses to schedule the pod if a future code path would let UID 0 reach the spec. Today, `set_user_id()` already rejects any UID below `REANA_KUBERNETES_JOBS_MIN_USER_UID` (default 100); this is just a defence-in-depth change at the cluster layer, complementing already-existing application-level UID guards in place.