### PR TITLE
feat(htcondorcern): add CPU/memory/disk/requirements hints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -73,6 +73,18 @@
         "htcondor_max_runtime": {
           "type": "string"
         },
+        "htcondor_request_cpus": {
+          "type": "string"
+        },
+        "htcondor_request_disk": {
+          "type": "string"
+        },
+        "htcondor_request_memory": {
+          "type": "string"
+        },
+        "htcondor_requirements": {
+          "type": "string"
+        },
         "job_name": {
           "type": "string"
         },

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,6 +21,7 @@ from retrying import retry
 from reana_commons.config import HTCONDOR_JOB_FLAVOURS
 
 from reana_job_controller.job_manager import JobManager
+from reana_job_controller.schemas import htcondor_quantity_to_unit
 from reana_job_controller.utils import initialize_krb5_token
 
 thread_local = threading.local()
@@ -52,6 +53,10 @@ class HTCondorJobManagerCERN(JobManager):
         unpacked_img=False,
         htcondor_max_runtime="",
         htcondor_accounting_group=None,
+        htcondor_request_cpus="",
+        htcondor_request_memory="",
+        htcondor_request_disk="",
+        htcondor_requirements="",
         **kwargs,
     ):
         """Instantiate HTCondor job manager.
@@ -80,6 +85,27 @@ class HTCondorJobManagerCERN(JobManager):
         :type htcondor_max_runtime: str
         :param htcondor_accounting_group: Accounting group of a HTCondor job.
         :type htcondor_accounting_group: str
+        :param htcondor_request_cpus: Number of CPU cores requested for the
+            HTCondor job (positive integer as string).
+        :type htcondor_request_cpus: str
+        :param htcondor_request_memory: Memory requested for the HTCondor
+            job. Accepts a positive integer with an optional
+            ``K|KB|M|MB|G|GB|T|TB`` suffix (case-insensitive, binary
+            multipliers). When no suffix is given, the value is interpreted
+            in megabytes, the native unit of ``RequestMemory``. Examples:
+            ``"4096"``, ``"4 GB"``, ``"4gb"``.
+        :type htcondor_request_memory: str
+        :param htcondor_request_disk: Disk requested for the HTCondor job.
+            Same quantity syntax as ``htcondor_request_memory``; when no
+            suffix is given, the value is interpreted in kilobytes, the
+            native unit of ``RequestDisk``. Examples: ``"10000"``,
+            ``"10 GB"``, ``"10tb"``.
+        :type htcondor_request_disk: str
+        :param htcondor_requirements: HTCondor ``Requirements`` ClassAd
+            expression to select the machine(s) the job can run on. REANA
+            does not compose this with any backend-provided default; the
+            value is the full expression.
+        :type htcondor_requirements: str
         """
         super(HTCondorJobManagerCERN, self).__init__(
             docker_img=docker_img,
@@ -97,6 +123,10 @@ class HTCondorJobManagerCERN(JobManager):
         self.unpacked_img = unpacked_img
         self.htcondor_max_runtime = htcondor_max_runtime
         self.htcondor_accounting_group = htcondor_accounting_group
+        self.htcondor_request_cpus = htcondor_request_cpus
+        self.htcondor_request_memory = htcondor_request_memory
+        self.htcondor_request_disk = htcondor_request_disk
+        self.htcondor_requirements = htcondor_requirements
 
         # We need to import the htcondor package later during runtime after the Kerberos environment is fully initialised.
         # Without a valid Kerberos ticket, importing will exit with "ERROR: Unauthorized 401 - do you have authentication tokens? Error "/usr/bin/myschedd.sh |"
@@ -147,6 +177,18 @@ class HTCondorJobManagerCERN(JobManager):
             job_ad["MaxRunTime"] = 3600
         if self.htcondor_accounting_group:
             job_ad["AccountingGroup"] = self.htcondor_accounting_group
+        if self.htcondor_request_cpus:
+            job_ad["RequestCpus"] = int(self.htcondor_request_cpus)
+        if self.htcondor_request_memory:
+            job_ad["RequestMemory"] = htcondor_quantity_to_unit(
+                self.htcondor_request_memory, "M"
+            )
+        if self.htcondor_request_disk:
+            job_ad["RequestDisk"] = htcondor_quantity_to_unit(
+                self.htcondor_request_disk, "K"
+            )
+        if self.htcondor_requirements:
+            job_ad["Requirements"] = classad.ExprTree(self.htcondor_requirements)
         future = current_app.htcondor_executor.submit(self._submit, job_ad)
         clusterid = future.result()
         return clusterid

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA Job Controller models."""
+
+import logging
+import re
 
 from marshmallow import Schema, fields, ValidationError, pre_load
 from reana_commons.job_utils import deserialise_job_command
@@ -16,6 +19,135 @@ from reana_job_controller.config import (
     REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
 )
+
+try:
+    import classad as _classad
+except ImportError:
+    # `classad` ships with the `htcondor` extras. In a correctly-built
+    # job-controller image this import must succeed. We do not fail at
+    # module load time so that test environments and non-HTCondor builds
+    # can still import this module, but we log a warning so misbuilt
+    # production images leave an obvious breadcrumb.
+    _classad = None
+    logging.getLogger(__name__).warning(
+        "classad library is not available; htcondor_requirements "
+        "expressions will not be validated at the schema layer. Expected "
+        "only in test environments and non-HTCondor builds."
+    )
+
+_POSITIVE_INTEGER_RE = re.compile(r"^[1-9]\d*$")
+
+HTCONDOR_QUANTITY_RE = re.compile(
+    r"^(?P<value>[1-9]\d*)\s*(?P<unit>K|KB|M|MB|G|GB|T|TB)?$",
+    re.IGNORECASE,
+)
+
+# HTCondor documents binary multipliers; both `K` and `KB` mean 1024 bytes,
+# `M`/`MB` mean 1024**2 bytes, and so on. There is no decimal "KB = 1000"
+# interpretation in the HTCondor manual.
+HTCONDOR_UNIT_BYTES = {
+    "K": 1024,
+    "KB": 1024,
+    "M": 1024**2,
+    "MB": 1024**2,
+    "G": 1024**3,
+    "GB": 1024**3,
+    "T": 1024**4,
+    "TB": 1024**4,
+}
+
+
+def htcondor_quantity_to_unit(value, default_unit):
+    """Convert an HTCondor quantity string to an integer in ``default_unit``.
+
+    HTCondor's submit-file syntax for ``RequestMemory`` and ``RequestDisk``
+    accepts a positive integer with an optional ``K|KB|M|MB|G|GB|T|TB``
+    suffix (case-insensitive). When the suffix is omitted, REANA falls back
+    to ``default_unit``: ``"M"`` for memory (matching ``RequestMemory``'s
+    native unit) and ``"K"`` for disk (matching ``RequestDisk``'s).
+
+    Conversion always rounds up. Using a smaller suffix than the native
+    unit (for example ``"1 KB"`` against the ``M`` native unit) yields at
+    least ``1``: a user request must never be silently down-converted to
+    zero or to a smaller value than asked for. ``"1536 KB"`` becomes
+    ``2`` MiB, not ``1``.
+
+    :param value: User-supplied quantity, e.g. ``"4 GB"`` or ``"4096"``.
+    :param default_unit: One of the keys of :data:`HTCONDOR_UNIT_BYTES`,
+        used when ``value`` has no explicit suffix.
+    :returns: Integer count of ``default_unit`` units, rounded up.
+    :raises ValueError: when ``value`` does not match the accepted format.
+    """
+    match = HTCONDOR_QUANTITY_RE.match(value)
+    if not match:
+        raise ValueError(
+            f"Invalid HTCondor quantity {value!r}: "
+            "expected a positive integer with optional K/KB/M/MB/G/GB/T/TB "
+            "suffix."
+        )
+    amount = int(match.group("value"))
+    unit = match.group("unit")
+    unit = unit.upper() if unit else default_unit
+    bytes_value = amount * HTCONDOR_UNIT_BYTES[unit]
+    divisor = HTCONDOR_UNIT_BYTES[default_unit]
+    # Ceiling division to avoid silently under-requesting.
+    return (bytes_value + divisor - 1) // divisor
+
+
+def _validate_positive_integer_string(field_name):
+    """Build a marshmallow validator for positive-integer string fields."""
+
+    def _validate(value):
+        if value in (None, ""):
+            return
+        if not _POSITIVE_INTEGER_RE.match(value):
+            raise ValidationError(
+                f"{field_name} must be a positive integer, got {value!r}."
+            )
+
+    return _validate
+
+
+def _validate_htcondor_quantity_string(field_name, default_unit):
+    """Build a marshmallow validator for HTCondor quantity-string fields.
+
+    Accepts ``"<positive int>[ <K|KB|M|MB|G|GB|T|TB>]"`` (case-insensitive).
+    The conversion result is discarded here; the manager re-runs the same
+    conversion when building the job_ad, so any error surfaces as a clean
+    400 with the original field name and value.
+    """
+
+    def _validate(value):
+        if value in (None, ""):
+            return
+        try:
+            htcondor_quantity_to_unit(value, default_unit)
+        except ValueError as exc:
+            raise ValidationError(f"{field_name}: {exc}")
+
+    return _validate
+
+
+def _validate_classad_expression(value):
+    """Validate that the value can be parsed as an HTCondor ClassAd expression.
+
+    No-op when the ``classad`` library is not importable. The
+    module-load-time warning above flags this state in production logs.
+    The HTCondor manager submission path imports ``classad`` at module
+    level, so a job-controller environment that lacks ``classad`` cannot
+    submit HTCondor jobs at all, regardless of whether schema validation
+    runs.
+    """
+    if value in (None, ""):
+        return
+    if _classad is None:
+        return
+    try:
+        _classad.ExprTree(value)
+    except (SyntaxError, RuntimeError, ValueError) as exc:
+        raise ValidationError(
+            f"htcondor_requirements is not a valid ClassAd expression: {exc}"
+        )
 
 
 class Job(Schema):
@@ -60,6 +192,22 @@ class JobRequest(Schema):
     unpacked_img = fields.Bool(required=False)
     htcondor_max_runtime = fields.Str(required=False)
     htcondor_accounting_group = fields.Str(required=False)
+    htcondor_request_cpus = fields.Str(
+        required=False,
+        validate=_validate_positive_integer_string("htcondor_request_cpus"),
+    )
+    htcondor_request_memory = fields.Str(
+        required=False,
+        validate=_validate_htcondor_quantity_string("htcondor_request_memory", "M"),
+    )
+    htcondor_request_disk = fields.Str(
+        required=False,
+        validate=_validate_htcondor_quantity_string("htcondor_request_disk", "K"),
+    )
+    htcondor_requirements = fields.Str(
+        required=False,
+        validate=_validate_classad_expression,
+    )
     slurm_partition = fields.Str(required=False)
     slurm_time = fields.Str(required=False)
     c4p_cpu_cores = fields.Str(required=False)

--- a/tests/test_htcondorcern_job_manager.py
+++ b/tests/test_htcondorcern_job_manager.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for the CERN HTCondor job manager."""
+
+from unittest import mock
+
+import pytest
+
+classad = pytest.importorskip("classad")
+pytest.importorskip("htcondor")
+
+from reana_job_controller import htcondorcern_job_manager  # noqa: E402
+
+
+@pytest.fixture
+def manager_dependencies():
+    """Patch the heavy dependencies of the HTCondor manager constructor."""
+    mock_workflow = mock.MagicMock()
+    mock_workflow.get_full_workflow_name.return_value = "wf"
+    with mock.patch.object(
+        htcondorcern_job_manager.HTCondorJobManagerCERN,
+        "_get_workflow",
+        return_value=mock_workflow,
+    ), mock.patch.object(htcondorcern_job_manager, "initialize_krb5_token"):
+        yield
+
+
+@pytest.fixture
+def captured_job_ad(manager_dependencies):
+    """Patch ``execute()``'s side-effecting helpers and capture the job_ad.
+
+    Returns a builder ``submit(**kwargs)`` that constructs the manager
+    with the given kwargs, calls ``execute()``, and returns the
+    ``classad.ClassAd`` that the manager would have sent to the schedd.
+    """
+    captured = {}
+
+    def fake_executor_submit(_fn, job_ad):
+        captured["job_ad"] = job_ad
+        future = mock.MagicMock()
+        future.result.return_value = "cluster123"
+        return future
+
+    fake_app = mock.MagicMock()
+    fake_app.htcondor_executor.submit.side_effect = fake_executor_submit
+
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+    with mock.patch.object(
+        htcondorcern_job_manager, "current_app", fake_app
+    ), mock.patch.object(htcondorcern_job_manager.os, "chdir"), mock.patch.object(
+        Manager, "_format_arguments", return_value="echo|base64 -d"
+    ), mock.patch.object(
+        Manager, "_format_env_vars", return_value=""
+    ), mock.patch.object(
+        Manager, "_get_input_files", return_value=""
+    ), mock.patch.object(
+        Manager, "before_execution"
+    ), mock.patch.object(
+        Manager, "create_job_in_db"
+    ):
+
+        def build_and_execute(**kwargs):
+            captured.clear()
+            base = dict(
+                docker_img="img",
+                cmd="ls",
+                env_vars={},
+                workflow_uuid="uuid",
+                workflow_workspace="/data",
+                job_name="job",
+                htcondor_max_runtime="3600",
+            )
+            base.update(kwargs)
+            manager = Manager(**base)
+            manager.execute()
+            return captured["job_ad"]
+
+        yield build_and_execute
+
+
+# --- constructor wiring -------------------------------------------------------
+
+
+def test_constructor_stores_htcondor_request_attributes(manager_dependencies):
+    """Constructor must store the four new HTCondor request attributes."""
+    manager = htcondorcern_job_manager.HTCondorJobManagerCERN(
+        docker_img="img",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid="uuid",
+        workflow_workspace="/data",
+        job_name="job",
+        htcondor_request_cpus="4",
+        htcondor_request_memory="4000",
+        htcondor_request_disk="100000",
+        htcondor_requirements='(Arch =?= "aarch64")',
+    )
+    assert manager.htcondor_request_cpus == "4"
+    assert manager.htcondor_request_memory == "4000"
+    assert manager.htcondor_request_disk == "100000"
+    assert manager.htcondor_requirements == '(Arch =?= "aarch64")'
+
+
+def test_constructor_defaults_htcondor_request_attributes_to_empty(
+    manager_dependencies,
+):
+    """When unset, the four new HTCondor request attributes default to empty."""
+    manager = htcondorcern_job_manager.HTCondorJobManagerCERN(
+        docker_img="img",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid="uuid",
+        workflow_workspace="/data",
+        job_name="job",
+    )
+    assert manager.htcondor_request_cpus == ""
+    assert manager.htcondor_request_memory == ""
+    assert manager.htcondor_request_disk == ""
+    assert manager.htcondor_requirements == ""
+
+
+# --- job_ad mapping in execute() ----------------------------------------------
+
+
+def test_execute_sets_request_cpus_as_int(captured_job_ad):
+    job_ad = captured_job_ad(htcondor_request_cpus="4")
+    assert int(job_ad["RequestCpus"]) == 4
+
+
+def test_execute_converts_request_memory_to_mib(captured_job_ad):
+    job_ad = captured_job_ad(htcondor_request_memory="4 GB")
+    assert int(job_ad["RequestMemory"]) == 4096
+
+
+def test_execute_rounds_up_request_memory(captured_job_ad):
+    """A ``1 KB`` request must not silently become ``0`` MiB."""
+    job_ad = captured_job_ad(htcondor_request_memory="1 KB")
+    assert int(job_ad["RequestMemory"]) == 1
+
+
+def test_execute_converts_request_disk_to_kib(captured_job_ad):
+    job_ad = captured_job_ad(htcondor_request_disk="10 GB")
+    assert int(job_ad["RequestDisk"]) == 10485760
+
+
+def test_execute_sets_requirements_as_classad_exprtree(captured_job_ad):
+    job_ad = captured_job_ad(htcondor_requirements='(Arch =?= "aarch64")')
+    expr = job_ad["Requirements"]
+    assert isinstance(expr, classad.ExprTree)
+    rendered = str(expr)
+    # Asserting on stable fragments rather than exact normal form, since
+    # classad's str() can vary in spacing/case across library versions.
+    assert "Arch" in rendered
+    assert "=?=" in rendered
+    assert "aarch64" in rendered
+
+
+def test_execute_omits_request_attrs_when_absent(captured_job_ad):
+    """Absent fields must not appear in the produced ClassAd."""
+    job_ad = captured_job_ad()
+    assert "RequestCpus" not in job_ad
+    assert "RequestMemory" not in job_ad
+    assert "RequestDisk" not in job_ad
+    assert "Requirements" not in job_ad

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for REANA-Job-Controller marshmallow schemas."""
+
+from unittest import mock
+
+import pytest
+from marshmallow import ValidationError
+from reana_commons.job_utils import serialise_job_command
+
+from reana_job_controller.schemas import JobRequest, htcondor_quantity_to_unit
+
+BASE_JOB_REQUEST = {
+    "job_name": "job",
+    "workflow_workspace": "/data",
+    "workflow_uuid": "uuid",
+    "docker_img": "img",
+    "cmd": serialise_job_command("ls"),
+    "kubernetes_job_timeout": 10,
+}
+
+
+@pytest.fixture(autouse=True)
+def _kubernetes_timeout_env():
+    """Patch the timeout config so the pre_load hook accepts our payload."""
+    with mock.patch(
+        "reana_job_controller.schemas.REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT", "60"
+    ), mock.patch(
+        "reana_job_controller.schemas.REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT",
+        "3600",
+    ):
+        yield
+
+
+def test_htcondor_request_cpus_accepts_positive_int_string():
+    """Positive integer strings are accepted for htcondor_request_cpus."""
+    loaded = JobRequest().load(dict(BASE_JOB_REQUEST, htcondor_request_cpus="4"))
+    assert loaded["htcondor_request_cpus"] == "4"
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "1.5", "4 GB", "abc", " "])
+def test_htcondor_request_cpus_rejects_invalid(bad_value):
+    """Non-positive-integer strings are rejected for htcondor_request_cpus."""
+    payload = dict(BASE_JOB_REQUEST, htcondor_request_cpus=bad_value)
+    with pytest.raises(ValidationError) as exc:
+        JobRequest().load(payload)
+    assert "htcondor_request_cpus" in exc.value.messages
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["htcondor_request_memory", "htcondor_request_disk"],
+)
+@pytest.mark.parametrize(
+    "value",
+    ["4096", "4GB", "4 GB", "4 gb", "10TB", "10 TB"],
+)
+def test_htcondor_request_quantity_field_accepts_valid(field, value):
+    """Valid quantity strings are accepted for memory/disk."""
+    loaded = JobRequest().load(dict(BASE_JOB_REQUEST, **{field: value}))
+    assert loaded[field] == value
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["htcondor_request_memory", "htcondor_request_disk"],
+)
+@pytest.mark.parametrize(
+    "bad_value",
+    ["0", "-1", "1.5GB", "4Gi", "4 XB", "GB", " ", "abc"],
+)
+def test_htcondor_request_quantity_field_rejects_invalid(field, bad_value):
+    """Invalid quantity strings are rejected for memory/disk."""
+    payload = dict(BASE_JOB_REQUEST, **{field: bad_value})
+    with pytest.raises(ValidationError) as exc:
+        JobRequest().load(payload)
+    assert field in exc.value.messages
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "htcondor_request_cpus",
+        "htcondor_request_memory",
+        "htcondor_request_disk",
+        "htcondor_requirements",
+    ],
+)
+def test_htcondor_field_absence_is_allowed(field):
+    """Omitting the new htcondor_* fields is always valid."""
+    payload = dict(BASE_JOB_REQUEST)
+    payload.pop(field, None)
+    JobRequest().load(payload)
+
+
+def test_htcondor_requirements_accepts_valid_classad_expression():
+    """A valid ClassAd expression passes the htcondor_requirements validator."""
+    pytest.importorskip("classad")
+    payload = dict(
+        BASE_JOB_REQUEST,
+        htcondor_requirements='(Arch =?= "aarch64")',
+    )
+    loaded = JobRequest().load(payload)
+    assert loaded["htcondor_requirements"] == '(Arch =?= "aarch64")'
+
+
+def test_htcondor_requirements_rejects_invalid_classad_expression():
+    """An unparseable ClassAd expression is rejected with a clear message."""
+    pytest.importorskip("classad")
+    payload = dict(
+        BASE_JOB_REQUEST,
+        htcondor_requirements="(Arch =?= ",
+    )
+    with pytest.raises(ValidationError) as exc:
+        JobRequest().load(payload)
+    assert "htcondor_requirements" in exc.value.messages
+
+
+@pytest.mark.parametrize(
+    "value, default_unit, expected",
+    [
+        # No suffix: value is already in default_unit.
+        ("4096", "M", 4096),
+        ("1000", "K", 1000),
+        # Suffix matches default_unit.
+        ("4096MB", "M", 4096),
+        ("4096 MB", "M", 4096),
+        ("1000KB", "K", 1000),
+        # Larger unit converts up (binary multipliers).
+        ("4GB", "M", 4096),
+        ("4 GB", "M", 4096),
+        ("4gb", "M", 4096),
+        ("10GB", "K", 10485760),
+        ("10 GB", "K", 10485760),
+        ("1TB", "G", 1024),
+        # Smaller unit divides down for exact multiples.
+        ("2048KB", "M", 2),
+        # Smaller unit rounds UP for non-exact multiples: a user request
+        # must never be silently down-converted to a smaller value.
+        ("1 KB", "M", 1),
+        ("1KB", "M", 1),
+        ("1536 KB", "M", 2),
+        # 1025 MiB = 1.0009... GiB, rounds up to 2 GiB.
+        ("1025 M", "G", 2),
+    ],
+)
+def test_htcondor_quantity_to_unit_conversions(value, default_unit, expected):
+    """The conversion helper produces correct integer counts."""
+    assert htcondor_quantity_to_unit(value, default_unit) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["0", "-1", "1.5GB", "4Gi", "4 XB", "GB", "", " ", "abc"],
+)
+def test_htcondor_quantity_to_unit_rejects_invalid(bad_value):
+    """Invalid quantity strings raise ValueError from the helper."""
+    with pytest.raises(ValueError):
+        htcondor_quantity_to_unit(bad_value, "M")


### PR DESCRIPTION
Adds four step-level parameters that map to the corresponding HTCondor
ClassAd attributes on the CERN HTCondor backend:

* htcondor_request_cpus -> RequestCpus
* htcondor_request_memory -> RequestMemory (MiB)
* htcondor_request_disk -> RequestDisk (KiB)
* htcondor_requirements -> Requirements

Memory and disk accept a positive integer with an optional
K/KB/M/MB/G/GB/T/TB suffix (case-insensitive, binary multipliers). The
suffix-less form is interpreted as the ClassAd attribute's native unit:
MiB for memory, KiB for disk. Conversion rounds up so '1 KB' becomes
1 MiB instead of 0. Kubernetes-style Gi/Mi suffixes are rejected to
avoid ambiguity.

The htcondor_requirements value is a free ClassAd expression and lets
users select on architecture, GPU, OpSys or any other matchable
attribute, for example '(Arch =?= "aarch64")'.

Validation lives in the JobRequest marshmallow schema; bad input
returns a 400 from the API rather than a 500 from the schedd.

Closes reanahub/reana-job-controller#502
