### PR TITLE
feat(job): honour scoped user secrets

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -116,6 +116,12 @@
         "rucio": {
           "type": "boolean"
         },
+        "secret_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "shared_file_system": {
           "default": true,
           "type": "boolean"

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -67,6 +67,8 @@ class HTCondorJobManagerCERN(JobManager):
         shared_file_system=False,
         job_name=None,
         kerberos=False,
+        secret_names=None,
+        secrets=None,
         kubernetes_uid=None,
         unpacked_img=False,
         htcondor_max_runtime="",
@@ -139,6 +141,8 @@ class HTCondorJobManagerCERN(JobManager):
         self.shared_file_system = shared_file_system
         self.workflow = self._get_workflow()
         self.unpacked_img = unpacked_img
+        self.secret_names = secret_names
+        self.secrets = secrets
         self.htcondor_max_runtime = htcondor_max_runtime
         self.htcondor_accounting_group = htcondor_accounting_group
         self.htcondor_request_cpus = htcondor_request_cpus
@@ -159,7 +163,15 @@ class HTCondorJobManagerCERN(JobManager):
         # Import HTCondor only after initialising Kerberos. Importing the module
         # evaluates the ``myschedd.sh`` configuration, which requires a valid
         # ticket.
-        initialize_krb5_token(workflow_uuid=self.workflow_uuid)
+        kerberos_secrets = (
+            self.secrets.get_scoped_secrets(self.secret_names, kerberos=True)
+            if self.secrets
+            else None
+        )
+        initialize_krb5_token(
+            workflow_uuid=self.workflow_uuid,
+            secrets=kerberos_secrets,
+        )
         globals()["htcondor"] = __import__("htcondor2")
 
     @JobManager.execution_hook

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -145,6 +145,12 @@ class KubernetesJobManager(JobManager):
     MAX_NUM_JOB_RESTARTS = 0
     """Maximum number of job restarts in case of internal failures."""
 
+    @staticmethod
+    def _get_secret_value(secrets: UserSecrets, name: str, default: str = "") -> str:
+        """Return a secret value as string when present."""
+        secret = secrets.get_secret(name)
+        return secret.value_str if secret else default
+
     def __init__(
         self,
         docker_img=None,
@@ -164,6 +170,7 @@ class KubernetesJobManager(JobManager):
         kubernetes_memory_limit=None,
         voms_proxy=False,
         rucio=False,
+        secret_names=None,
         kubernetes_job_timeout: Optional[int] = None,
         secrets: Optional[UserSecrets] = None,
         **kwargs,
@@ -202,6 +209,9 @@ class KubernetesJobManager(JobManager):
         :param rucio: Decides if a rucio environment should be provided
             for job.
         :type rucio: bool
+        :param secret_names: Explicit allowlist of user secret names to expose
+            to the job pod. If unset, all user secrets remain available.
+        :type secret_names: Optional[list[str]]
         :param secrets: User secrets, if none they will be fetched from k8s.
         :type secrets: Optional[UserSecrets]
         """
@@ -221,6 +231,7 @@ class KubernetesJobManager(JobManager):
         self.kerberos = kerberos
         self.voms_proxy = voms_proxy
         self.rucio = rucio
+        self.secret_names = secret_names
         self.set_user_id(kubernetes_uid)
         self.workflow_uuid = workflow_uuid
         self.kubernetes_job_timeout = kubernetes_job_timeout
@@ -293,13 +304,25 @@ class KubernetesJobManager(JobManager):
                 "securityContext"
             ] = _restricted_container_security_context()
 
-        secret_env_vars = self.secrets.get_env_secrets_as_k8s_spec()
         job_spec = self.job["spec"]["template"]["spec"]
-        job_spec["containers"][0]["env"].extend(secret_env_vars)
-        job_spec["volumes"].append(self.secrets.get_file_secrets_volume_as_k8s_specs())
-
-        secrets_volume_mount = self.secrets.get_secrets_volume_mount_as_k8s_spec()
-        job_spec["containers"][0]["volumeMounts"].append(secrets_volume_mount)
+        exposed_secrets = self.secrets.get_scoped_secrets(
+            self.secret_names,
+            kerberos=self.kerberos,
+            voms_proxy=self.voms_proxy,
+            rucio=self.rucio,
+        )
+        secret_env_vars = exposed_secrets.get_env_secrets_as_k8s_spec()
+        secrets_volume_mount = None
+        if exposed_secrets.get_secrets():
+            job_spec["containers"][0]["env"].extend(secret_env_vars)
+        if exposed_secrets.has_file_secrets():
+            job_spec["volumes"].append(
+                exposed_secrets.get_file_secrets_volume_as_k8s_specs()
+            )
+            secrets_volume_mount = (
+                exposed_secrets.get_secrets_volume_mount_as_k8s_spec()
+            )
+            job_spec["containers"][0]["volumeMounts"].append(secrets_volume_mount)
 
         if self.env_vars:
             for var, value in self.env_vars.items():
@@ -329,13 +352,13 @@ class KubernetesJobManager(JobManager):
             )
 
         if self.kerberos:
-            self._add_krb5_containers(self.secrets)
+            self._add_krb5_containers(exposed_secrets)
 
         if self.voms_proxy:
-            self._add_voms_proxy_init_container(secrets_volume_mount, secret_env_vars)
+            self._add_voms_proxy_init_container(secrets_volume_mount, exposed_secrets)
 
         if self.rucio:
-            self._add_rucio_init_container(secrets_volume_mount, secret_env_vars)
+            self._add_rucio_init_container(secrets_volume_mount, exposed_secrets)
 
         if REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL:
             self.job["spec"]["template"]["spec"][
@@ -637,8 +660,9 @@ class KubernetesJobManager(JobManager):
             f"trap 'touch {KRB5_STATUS_FILE_LOCATION}' EXIT; " + self.cmd
         ]
 
-    def _add_voms_proxy_init_container(self, secrets_volume_mount, secret_env_vars):
+    def _add_voms_proxy_init_container(self, secrets_volume_mount, exposed_secrets):
         """Add sidecar container for a job."""
+        secret_env_vars = exposed_secrets.get_env_secrets_as_k8s_spec()
         ticket_cache_volume = {"name": "voms-proxy-cache", "emptyDir": {}}
         volume_mounts = [
             {
@@ -652,8 +676,8 @@ class KubernetesJobManager(JobManager):
             current_app.config["VOMSPROXY_CERT_CACHE_FILENAME"],
         )
 
-        voms_proxy_vo = os.environ.get("VONAME", "")
-        voms_proxy_user_file = os.environ.get("VOMSPROXY_FILE", "")
+        voms_proxy_vo = self._get_secret_value(exposed_secrets, "VONAME")
+        voms_proxy_user_file = self._get_secret_value(exposed_secrets, "VOMSPROXY_FILE")
 
         if voms_proxy_user_file:
             # multi-user deployment mode, where we rely on VOMS proxy file supplied by the user
@@ -738,8 +762,9 @@ class KubernetesJobManager(JobManager):
             voms_proxy_container
         )
 
-    def _add_rucio_init_container(self, secrets_volume_mount, secret_env_vars):
+    def _add_rucio_init_container(self, secrets_volume_mount, exposed_secrets):
         """Add sidecar container for a job."""
+        secret_env_vars = exposed_secrets.get_env_secrets_as_k8s_spec()
         ticket_cache_volume = {"name": "rucio-cache", "emptyDir": {}}
         volume_mounts = [
             {
@@ -758,8 +783,8 @@ class KubernetesJobManager(JobManager):
             current_app.config["RUCIO_CERN_BUNDLE_CACHE_FILENAME"],
         )
 
-        rucio_account = os.environ.get("RUCIO_USERNAME", "")
-        voms_proxy_vo = os.environ.get("VONAME", "")
+        rucio_account = self._get_secret_value(exposed_secrets, "RUCIO_USERNAME")
+        voms_proxy_vo = self._get_secret_value(exposed_secrets, "VONAME")
 
         # Detect Rucio hosts from VO names
         if voms_proxy_vo == "atlas":
@@ -770,8 +795,16 @@ class KubernetesJobManager(JobManager):
             rucio_auth_host = f"https://{voms_proxy_vo}-rucio-auth.cern.ch"
 
         # Allow overriding detected Rucio hosts by user-provided environment variables
-        rucio_host = os.environ.get("RUCIO_RUCIO_HOST", rucio_host)
-        rucio_auth_host = os.environ.get("RUCIO_AUTH_HOST", rucio_auth_host)
+        rucio_host = self._get_secret_value(
+            exposed_secrets,
+            "RUCIO_RUCIO_HOST",
+            rucio_host,
+        )
+        rucio_auth_host = self._get_secret_value(
+            exposed_secrets,
+            "RUCIO_AUTH_HOST",
+            rucio_auth_host,
+        )
 
         rucio_config_container = {
             "image": current_app.config["RUCIO_CONTAINER_IMAGE"],

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -11,6 +11,7 @@
 import copy
 import json
 import logging
+import os
 import threading
 
 import marshmallow
@@ -22,6 +23,7 @@ from reana_commons.errors import (
     REANAKubernetesCPULimitExceeded,
     REANAKubernetesWrongCPUFormat,
     REANAKubernetesUIDBelowMinimum,
+    REANASecretDoesNotExist,
 )
 
 from reana_db.models import JobStatus
@@ -64,7 +66,15 @@ def get_cached_user_secrets() -> UserSecrets:
     """Return cached user secrets."""
     global _SECRETS_CACHE
     if _SECRETS_CACHE is None:
-        _SECRETS_CACHE = UserSecretsStore.fetch(config.REANA_USER_ID)
+        secrets_types = os.getenv("REANA_USER_SECRETS_TYPES")
+        if secrets_types is not None:
+            _SECRETS_CACHE = UserSecrets.from_pod_secrets(
+                user_id=config.REANA_USER_ID,
+                secrets_types=json.loads(secrets_types),
+                mount_path=os.getenv("REANA_USER_SECRET_MOUNT_PATH"),
+            )
+        else:
+            _SECRETS_CACHE = UserSecretsStore.fetch(config.REANA_USER_ID)
     return _SECRETS_CACHE
 
 
@@ -327,6 +337,8 @@ def create_job():  # noqa
             return jsonify({"message": e.message}), 400
         except REANAKubernetesUIDBelowMinimum as e:
             return jsonify({"message": e.message}), 403
+        except REANASecretDoesNotExist as e:
+            return jsonify({"message": str(e)}), 400
     if not job_creation_condition.start_creation():
         return jsonify({"message": "Cannot create new jobs, shutting down"}), 400
 
@@ -336,6 +348,8 @@ def create_job():  # noqa
         msg = f"Job submission failed because of DB connection issues. \n{e}"
         logging.error(msg, exc_info=True)
         return jsonify({"message": msg}), 500
+    except REANASecretDoesNotExist as e:
+        return jsonify({"message": str(e)}), 400
     except Exception as e:
         msg = f"Job submission failed. \n{e}"
         logging.error(msg, exc_info=True)

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -183,6 +183,7 @@ class JobRequest(Schema):
     kerberos = fields.Bool(required=False)
     voms_proxy = fields.Bool(required=False)
     rucio = fields.Bool(required=False)
+    secret_names = fields.List(fields.Str(), required=False)
     kubernetes_uid = fields.Int(required=False)
     kubernetes_cpu_request = fields.Str(required=False)
     kubernetes_cpu_limit = fields.Str(required=False)

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -14,7 +14,10 @@ import shlex
 from stat import S_ISDIR
 
 from reana_job_controller.job_manager import JobManager
-from reana_job_controller.utils import SSHClient, initialize_krb5_token
+from reana_job_controller.utils import (
+    SSHClient,
+    initialize_krb5_token,
+)
 from reana_job_controller.config import (
     SLURM_HEADNODE_GSS_HOSTNAME,
     SLURM_HEADNODE_HOSTNAME,
@@ -53,6 +56,9 @@ class SlurmJobManagerCERN(JobManager):
         cvmfs_mounts="false",
         shared_file_system=False,
         job_name=None,
+        kerberos=False,
+        secret_names=None,
+        secrets=None,
         slurm_partition=SLURM_PARTITION,
         slurm_job_timelimit=SLURM_JOB_TIMELIMIT,
         **kwargs,
@@ -94,6 +100,9 @@ class SlurmJobManagerCERN(JobManager):
         self.workflow_workspace = workflow_workspace
         self.cvmfs_mounts = cvmfs_mounts
         self.shared_file_system = shared_file_system
+        self.kerberos = kerberos
+        self.secret_names = secret_names
+        self.secrets = secrets
         self.job_file = "job.sh"
         self.job_description_file = "job_description.sh"
         self.partition = slurm_partition
@@ -129,7 +138,15 @@ class SlurmJobManagerCERN(JobManager):
     def execute(self):
         """Execute / submit a job with Slurm."""
         self.cmd = self._encode_cmd(self.cmd)
-        initialize_krb5_token(workflow_uuid=self.workflow_uuid)
+        kerberos_secrets = (
+            self.secrets.get_scoped_secrets(self.secret_names, kerberos=True)
+            if self.secrets
+            else None
+        )
+        initialize_krb5_token(
+            workflow_uuid=self.workflow_uuid,
+            secrets=kerberos_secrets,
+        )
         self.slurm_connection = SSHClient(
             hostname=SLURM_HEADNODE_HOSTNAME,
             gss_host=SLURM_HEADNODE_GSS_HOSTNAME,

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -18,7 +18,6 @@ from logging import Formatter, LogRecord
 
 from io import StringIO
 from typing import List, Tuple
-
 from reana_db.database import Session
 from reana_db.models import Workflow
 
@@ -71,10 +70,17 @@ def update_workflow_logs(workflow_uuid, log_message):
         logging.error("Exception while saving logs: {}".format(str(e)), exc_info=True)
 
 
-def initialize_krb5_token(workflow_uuid):
-    """Create kerberos ticket from mounted keytab_file."""
-    cern_user = os.environ.get("CERN_USER")
-    keytab_file = os.environ.get("CERN_KEYTAB")
+def initialize_krb5_token(workflow_uuid, secrets=None):
+    """Create kerberos ticket from the scoped user secrets."""
+    cern_user_secret = secrets.get_secret("CERN_USER") if secrets else None
+    keytab_secret = secrets.get_secret("CERN_KEYTAB") if secrets else None
+
+    cern_user = (
+        cern_user_secret.value_str if cern_user_secret else os.environ.get("CERN_USER")
+    )
+    keytab_file = (
+        keytab_secret.value_str if keytab_secret else os.environ.get("CERN_KEYTAB")
+    )
     cmd = "kinit -kt /etc/reana/secrets/{} {}@CERN.CH".format(keytab_file, cern_user)
 
     if cern_user:

--- a/tests/test_htcondorcern_job_manager.py
+++ b/tests/test_htcondorcern_job_manager.py
@@ -17,6 +17,7 @@ import pytest
 classad = pytest.importorskip("classad2")
 htcondor = pytest.importorskip("htcondor2")
 
+from reana_commons.k8s.secrets import Secret, UserSecrets  # noqa: E402
 from reana_job_controller import htcondorcern_job_manager  # noqa: E402
 from reana_job_controller import job_monitor  # noqa: E402
 
@@ -138,6 +139,38 @@ def test_constructor_defaults_htcondor_request_attributes_to_empty(
     assert manager.htcondor_request_memory == ""
     assert manager.htcondor_request_disk == ""
     assert manager.htcondor_requirements == ""
+
+
+def test_constructor_scopes_kerberos_secrets_for_backend_auth(manager_dependencies):
+    """HTCondor auth should preserve Kerberos secrets even with ``secret_names: []``."""
+    all_user_secrets = UserSecrets(
+        user_id="123",
+        k8s_secret_name="k8s-secret",
+        secrets=[
+            Secret("ordinary", "env", "1"),
+            Secret("CERN_USER", "env", "johndoe"),
+            Secret("CERN_KEYTAB", "env", ".keytab"),
+            Secret(".keytab", "file", b"keytab"),
+        ],
+    )
+
+    with mock.patch.object(
+        htcondorcern_job_manager,
+        "initialize_krb5_token",
+    ) as initialize_krb5_token:
+        htcondorcern_job_manager.HTCondorJobManagerCERN(
+            docker_img="img",
+            cmd="ls",
+            env_vars={},
+            workflow_uuid="uuid",
+            workflow_workspace="/data",
+            job_name="job",
+            secret_names=[],
+            secrets=all_user_secrets,
+        )
+
+    scoped_secrets = initialize_krb5_token.call_args.kwargs["secrets"]
+    assert list(scoped_secrets.secrets) == ["CERN_USER", "CERN_KEYTAB", ".keytab"]
 
 
 # --- submit-description mapping in execute() ----------------------------------

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -203,6 +203,199 @@ def test_slurm_image_cache_names_do_not_clash():
     assert len(stems) == 2
 
 
+def test_execute_kubernetes_job_filters_secret_names(
+    app,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    user_secrets,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test execution of Kubernetes job with a filtered secret allowlist."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        secret_names=["username", ".keytab"],
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+            env_names = {
+                env_var["name"] for env_var in job_spec["containers"][0]["env"]
+            }
+            secret_volume = next(
+                volume
+                for volume in job_spec["volumes"]
+                if volume["name"].startswith("reana-secretsstore")
+            )
+
+            assert "username" in env_names
+            assert "password" not in env_names
+            assert secret_volume["secret"]["items"] == [
+                {"key": ".keytab", "path": ".keytab"}
+            ]
+
+
+def test_execute_kubernetes_job_does_not_mount_env_only_secret_scope(
+    app,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    user_secrets,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """An env-only scope must not project file secrets through an empty volume."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        secret_names=["username"],
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(user_secrets),
+        ):
+            job_manager.execute()
+
+    job_spec = kubernetes_client.create_namespaced_job.call_args[1]["body"]["spec"][
+        "template"
+    ]["spec"]
+    assert "username" in {
+        env_var["name"] for env_var in job_spec["containers"][0]["env"]
+    }
+    assert not any(
+        volume["name"].startswith("reana-secretsstore")
+        for volume in job_spec["volumes"]
+    )
+
+
+def test_execute_kubernetes_job_keeps_feature_secrets_for_kerberos(
+    app,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Kerberos jobs keep feature secrets even when ordinary ones are scoped away."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    kerberos_user_secrets = {
+        "ordinary": _build_user_secret("1", "env"),
+        "CERN_USER": _build_user_secret("johndoe", "env"),
+        "CERN_KEYTAB": _build_user_secret(".keytab", "env"),
+        ".keytab": _build_user_secret("keytab file", "file"),
+    }
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        kerberos=True,
+        secret_names=[],
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(kerberos_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+            env_names = {
+                env_var["name"] for env_var in job_spec["containers"][0]["env"]
+            }
+            secret_volume = next(
+                volume
+                for volume in job_spec["volumes"]
+                if volume["name"].startswith("reana-secretsstore")
+            )
+
+            assert "CERN_USER" in env_names
+            assert "CERN_KEYTAB" in env_names
+            assert "ordinary" not in env_names
+            assert secret_volume["secret"]["items"] == [
+                {"key": ".keytab", "path": ".keytab"}
+            ]
+
+
+def test_execute_kubernetes_job_keeps_feature_secrets_for_voms_proxy(
+    app,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """VOMS jobs must derive feature secret values from the scoped secret set."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    monkeypatch.delenv("VONAME", raising=False)
+    monkeypatch.delenv("VOMSPROXY_FILE", raising=False)
+    voms_user_secrets = {
+        "ordinary": _build_user_secret("1", "env"),
+        "VOMSPROXY_FILE": _build_user_secret("proxy.pem", "env"),
+        "proxy.pem": _build_user_secret("proxy file", "file"),
+    }
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        voms_proxy=True,
+        secret_names=[],
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client, mock.patch(
+        "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+        corev1_api_client_with_user_secrets(voms_user_secrets),
+    ):
+        job_manager.execute()
+        body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+        init_container = next(
+            container
+            for container in body["spec"]["template"]["spec"]["initContainers"]
+            if container["name"] == app.config["VOMSPROXY_CONTAINER_NAME"]
+        )
+
+        assert "proxy.pem" in init_container["args"][1]
+        assert "voms-proxy-init" not in init_container["args"][1]
+
+
 def test_execute_kubernetes_job_with_voms_proxy_init_container(
     app,
     session,
@@ -249,6 +442,59 @@ def test_execute_kubernetes_job_with_voms_proxy_init_container(
                 "capabilities": {"drop": ["ALL"]},
                 "seccompProfile": {"type": "RuntimeDefault"},
             }
+
+
+def test_execute_kubernetes_job_keeps_feature_secrets_for_rucio(
+    app,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Rucio jobs must derive feature secret values from the scoped secret set."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    monkeypatch.delenv("VONAME", raising=False)
+    monkeypatch.delenv("RUCIO_USERNAME", raising=False)
+    monkeypatch.delenv("RUCIO_RUCIO_HOST", raising=False)
+    monkeypatch.delenv("RUCIO_AUTH_HOST", raising=False)
+    rucio_user_secrets = {
+        "ordinary": _build_user_secret("1", "env"),
+        "VONAME": _build_user_secret("atlas", "env"),
+        "RUCIO_USERNAME": _build_user_secret("johndoe", "env"),
+        "RUCIO_RUCIO_HOST": _build_user_secret("https://rucio.example", "env"),
+        "RUCIO_AUTH_HOST": _build_user_secret("https://auth.example", "env"),
+    }
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        rucio=True,
+        secret_names=[],
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client, mock.patch(
+        "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+        corev1_api_client_with_user_secrets(rucio_user_secrets),
+    ):
+        job_manager.execute()
+        body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+        init_container = next(
+            container
+            for container in body["spec"]["template"]["spec"]["initContainers"]
+            if container["name"] == app.config["RUCIO_CONTAINER_NAME"]
+        )
+
+        assert "RUCIO_CFG_ACCOUNT=johndoe" in init_container["args"][1]
+        assert "RUCIO_CFG_CLIENT_VO=atlas" in init_container["args"][1]
+        assert "RUCIO_CFG_RUCIO_HOST=https://rucio.example" in init_container["args"][1]
+        assert "RUCIO_CFG_AUTH_HOST=https://auth.example" in init_container["args"][1]
 
 
 def test_execute_kubernetes_job_with_rucio_init_container(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,8 +12,12 @@ from unittest import mock
 import pytest
 
 import reana_job_controller.utils as utils
+from reana_commons.k8s.secrets import Secret, UserSecrets
 from reana_job_controller.config import SLURM_PARTITION
-from reana_job_controller.utils import MultilineFormatter
+from reana_job_controller.utils import (
+    MultilineFormatter,
+    initialize_krb5_token,
+)
 
 """REANA-Job-Controller utils tests."""
 
@@ -214,3 +218,25 @@ def test_ssh_client_exec_command_raises_remote_errors():
 def test_slurm_partition_uses_current_cern_default():
     """Test default Slurm partition follows the current CERN cluster."""
     assert SLURM_PARTITION == "photon"
+
+
+def test_initialize_krb5_token_uses_scoped_secrets(monkeypatch):
+    """Kerberos auth should read credentials from the scoped secret set."""
+    scoped_secrets = UserSecrets(
+        user_id="123",
+        k8s_secret_name="k8s-secret",
+        secrets=[
+            Secret("CERN_USER", "env", "johndoe"),
+            Secret("CERN_KEYTAB", "env", ".keytab"),
+        ],
+    )
+    monkeypatch.delenv("CERN_USER", raising=False)
+    monkeypatch.delenv("CERN_KEYTAB", raising=False)
+
+    with mock.patch("reana_job_controller.utils.subprocess.check_output") as mocked:
+        initialize_krb5_token("workflow-uuid", secrets=scoped_secrets)
+
+    mocked.assert_called_once_with(
+        "kinit -kt /etc/reana/secrets/.keytab johndoe@CERN.CH",
+        shell=True,
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,13 +10,16 @@
 
 import json
 import uuid
+from pathlib import Path
 
 import pytest
 from flask import current_app, url_for
 from kubernetes.client.rest import ApiException
 from mock import Mock, patch
 from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+from reana_commons.errors import REANASecretDoesNotExist
 from reana_commons.job_utils import serialise_job_command
+from reana_job_controller import rest
 
 from reana_job_controller.job_db import JOB_DB
 
@@ -240,3 +243,78 @@ def test_create_job_allows_vetted_images(app, job_spec, monkeypatch, vetting_con
 
     assert response.status_code == 400
     assert response.json == {"message": "Cannot create new jobs, shutting down"}
+
+
+@patch("reana_job_controller.schemas.REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT", "10")
+@patch(
+    "reana_job_controller.schemas.REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT", "20"
+)
+def test_create_job_returns_400_for_constructor_time_secret_scope_errors(
+    app,
+    job_spec,
+    monkeypatch,
+):
+    """Secret scoping errors raised before execute() should still return 400."""
+
+    class ExplodingManager:
+        def __init__(self, **kwargs):
+            raise REANASecretDoesNotExist(["missing"])
+
+    job_spec["compute_backend"] = "test"
+    job_spec["cmd"] = serialise_job_command("ls")
+    app.config["REANA_VETTED_CONTAINER_IMAGES"] = {
+        "enabled": False,
+        "allowlist": [],
+    }
+    monkeypatch.setitem(app.config, "SUPPORTED_COMPUTE_BACKENDS", ["test"])
+    monkeypatch.setitem(
+        app.config,
+        "COMPUTE_BACKENDS",
+        {"test": lambda: ExplodingManager},
+    )
+
+    with (
+        patch(
+            "reana_job_controller.rest.get_cached_user_secrets",
+            return_value={},
+        ),
+        patch(
+            "reana_job_controller.rest.job_creation_condition.start_creation"
+        ) as start,
+        app.test_client() as client,
+    ):
+        response = client.post(
+            url_for("jobs.create_job"),
+            content_type="application/json",
+            data=json.dumps(job_spec),
+        )
+
+    assert response.status_code == 400
+    assert response.json == {
+        "message": "Operation cancelled. Secrets ['missing'] do not exist."
+    }
+    start.assert_not_called()
+
+
+def test_get_cached_user_secrets_rebuilds_from_scoped_pod_secrets(
+    tmp_path, monkeypatch
+):
+    """Scoped sidecar caches should be rebuilt from pod env/files, not k8s fetches."""
+    keytab_path = Path(tmp_path) / ".keytab"
+    keytab_path.write_bytes(b"keytab file")
+
+    rest._SECRETS_CACHE = None
+    monkeypatch.setenv(
+        "REANA_USER_SECRETS_TYPES", json.dumps({"username": "env", ".keytab": "file"})
+    )
+    monkeypatch.setenv("REANA_USER_SECRET_MOUNT_PATH", str(tmp_path))
+    monkeypatch.setenv("username", "johndoe")
+    monkeypatch.setattr("reana_job_controller.config.REANA_USER_ID", "123")
+
+    with patch("reana_job_controller.rest.UserSecretsStore.fetch") as fetch:
+        user_secrets = rest.get_cached_user_secrets()
+
+    assert user_secrets.get_secret("username").value_str == "johndoe"
+    assert user_secrets.get_secret(".keytab").value_bytes == b"keytab file"
+    fetch.assert_not_called()
+    rest._SECRETS_CACHE = None


### PR DESCRIPTION
Filter job-side secret injection through requested secret names, preserve backend and feature credentials where needed, and return clear validation errors when unknown secret names reach the job controller.

Closes reanahub/reana#978