### PR TITLE
feat(runtime): bootstrap job-controller as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 # Changelog
 
+## [Unreleased](https://github.com/reanahub/reana-job-controller/compare/0.9.4...HEAD)
+
+### Documentation
+
+* **kubernetes:** note that user job containers now run with `capabilities.drop: [ALL]` and `seccompProfile: RuntimeDefault` when `K8S_USE_SECURITY_CONTEXT` is enabled, which may require adjustments for workflow images that depend on extra Linux capabilities or unconfined syscalls
+
 ## [0.9.4](https://github.com/reanahub/reana-job-controller/compare/0.9.3...0.9.4) (2024-11-29)
 
 ### Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
       git \
       gcc \
+      libnss-wrapper \
       krb5-config \
       krb5-user \
       libauthen-krb5-simple-perl \
@@ -84,6 +85,22 @@ COPY etc/job_wrapper.sh /etc/job_wrapper.sh
 RUN chmod +x /etc/job_wrapper.sh && \
     update-ca-certificates
 
+# Resolve libnss_wrapper at build time and prepare runtime directories
+RUN LIBNSS_WRAPPER_PATH="" && \
+    for candidate in $(dpkg -L libnss-wrapper); do \
+      case "${candidate}" in \
+        */libnss_wrapper.so) \
+          LIBNSS_WRAPPER_PATH="${candidate}"; \
+          break; \
+          ;; \
+      esac; \
+    done && \
+    test -n "${LIBNSS_WRAPPER_PATH}" && \
+    mkdir -p /usr/local/lib /var/run/nss_wrapper && \
+    ln -sf "${LIBNSS_WRAPPER_PATH}" /usr/local/lib/libnss_wrapper.so && \
+    chown -R 1000:0 /var/run/nss_wrapper && \
+    chmod -R g+rwx /var/run/nss_wrapper
+
 # Copy cluster component source code
 WORKDIR /code
 COPY . /code
@@ -132,17 +149,30 @@ RUN pip check
 # Set useful environment variables
 ENV COMPUTE_BACKENDS=$COMPUTE_BACKENDS \
     FLASK_APP=reana_job_controller/app.py \
+    K8S_USE_SECURITY_CONTEXT=True \
+    LIBNSS_WRAPPER_PATH=/usr/local/lib/libnss_wrapper.so \
+    NSS_WRAPPER_GROUP=/var/run/nss_wrapper/group \
+    NSS_WRAPPER_PASSWD=/var/run/nss_wrapper/passwd \
     TERM=xterm
 
-# Delete default `ubuntu` user, as its UID (1000) clashes with REANA's default one
-# See https://bugs.launchpad.net/cloud-images/+bug/2005129
-RUN userdel -r ubuntu
+# Default caches and HTCondor runtime files live under /tmp so the
+# OpenShift-style arbitrary UID/GID path remains writable too.
+ENV HOME=/tmp/reana-job-controller \
+    TMPDIR=/tmp \
+    WORKFLOW_RUNTIME_GROUP_NAME=root \
+    WORKFLOW_RUNTIME_USER_GID=0 \
+    WORKFLOW_RUNTIME_USER_NAME=reana \
+    WORKFLOW_RUNTIME_USER_UID=1000 \
+    XDG_CACHE_HOME=/tmp/reana-job-controller/.cache
 
 # Expose ports to clients
 EXPOSE 5000
 
-# Run server (in a full REANA deployment, this is overridden at runtime by reana-workflow-controller)
-CMD ["flask", "run", "-h", "0.0.0.0"]
+# Run server. In a full REANA deployment the wrapper is still invoked via
+# reana-workflow-controller, but the wrapper itself decides between uwsgi and
+# the Flask development server depending on runtime context.
+USER 1000:0
+CMD ["python3", "-m", "reana_job_controller.nss_wrapper"]
 
 # Set image labels
 LABEL org.opencontainers.image.authors="team@reanahub.io"

--- a/reana_job_controller/kubernetes_job_manager.py
+++ b/reana_job_controller/kubernetes_job_manager.py
@@ -19,6 +19,7 @@ from kubernetes.client.rest import ApiException
 from reana_commons.config import (
     K8S_CERN_EOS_AVAILABLE,
     K8S_CERN_EOS_MOUNT_CONFIGURATION,
+    K8S_USE_SECURITY_CONTEXT,
     KRB5_STATUS_FILE_LOCATION,
     REANA_JOB_HOSTPATH_MOUNTS,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
@@ -70,6 +71,70 @@ from reana_job_controller.config import (
 )
 from reana_job_controller.errors import ComputingBackendSubmissionError
 from reana_job_controller.job_manager import JobManager
+
+
+def _restricted_container_security_context(
+    kubernetes_uid: Optional[int] = None,
+    kubernetes_gid: int = WORKFLOW_RUNTIME_USER_GID,
+) -> dict:
+    """Return a PSA-restricted container security context."""
+    security_context = {
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    if kubernetes_uid is not None:
+        security_context["runAsUser"] = int(kubernetes_uid)
+        security_context["runAsGroup"] = int(kubernetes_gid)
+    return security_context
+
+
+def _normalize_kerberos_container_security_context(
+    kerberos_config, kubernetes_uid: int
+):
+    """Backfill missing Kerberos security-context fields from older commons releases."""
+    if not K8S_USE_SECURITY_CONTEXT:
+        return kerberos_config
+
+    for container_name in ("init_container", "renew_container"):
+        container = getattr(kerberos_config, container_name, None)
+        if not container:
+            continue
+
+        expected_security_context = _restricted_container_security_context(
+            kubernetes_uid
+        )
+        if "securityContext" not in container:
+            container["securityContext"] = expected_security_context
+            continue
+
+        for field, value in expected_security_context.items():
+            if field not in container["securityContext"]:
+                container["securityContext"][field] = value
+
+    return kerberos_config
+
+
+def _get_compatible_kerberos_k8s_config(secrets, kubernetes_uid: int):
+    """Return Kerberos k8s config across released and unreleased commons APIs."""
+    try:
+        kerberos_config = get_kerberos_k8s_config(
+            secrets,
+            kubernetes_uid=kubernetes_uid,
+            use_security_context=K8S_USE_SECURITY_CONTEXT,
+        )
+    except TypeError as exc:
+        if "unexpected keyword argument 'use_security_context'" not in str(exc):
+            raise
+        kerberos_config = get_kerberos_k8s_config(
+            secrets,
+            kubernetes_uid=kubernetes_uid,
+        )
+    return _normalize_kerberos_container_security_context(
+        kerberos_config,
+        kubernetes_uid,
+    )
 
 
 class KubernetesJobManager(JobManager):
@@ -209,8 +274,8 @@ class KubernetesJobManager(JobManager):
                                 "args": [self.cmd],
                                 "name": "job",
                                 "env": [],
-                                "volumeMounts": [],
                                 "securityContext": {"allowPrivilegeEscalation": False},
+                                "volumeMounts": [],
                             }
                         ],
                         "initContainers": [],
@@ -223,6 +288,10 @@ class KubernetesJobManager(JobManager):
                 },
             },
         }
+        if K8S_USE_SECURITY_CONTEXT:
+            self.job["spec"]["template"]["spec"]["containers"][0][
+                "securityContext"
+            ] = _restricted_container_security_context()
 
         secret_env_vars = self.secrets.get_env_secrets_as_k8s_spec()
         job_spec = self.job["spec"]["template"]["spec"]
@@ -250,13 +319,14 @@ class KubernetesJobManager(JobManager):
             job_spec["containers"][0]["volumeMounts"].extend(volume_mounts)
             job_spec["volumes"].extend(volumes)
 
-        self.job["spec"]["template"]["spec"]["securityContext"] = (
-            client.V1PodSecurityContext(
-                run_as_group=WORKFLOW_RUNTIME_USER_GID,
-                run_as_user=self.kubernetes_uid,
-                run_as_non_root=True,
+        if K8S_USE_SECURITY_CONTEXT:
+            self.job["spec"]["template"]["spec"]["securityContext"] = (
+                client.V1PodSecurityContext(
+                    run_as_group=int(WORKFLOW_RUNTIME_USER_GID),
+                    run_as_user=int(self.kubernetes_uid),
+                    run_as_non_root=True,
+                )
             )
-        )
 
         if self.kerberos:
             self._add_krb5_containers(self.secrets)
@@ -537,7 +607,7 @@ class KubernetesJobManager(JobManager):
 
     def _add_krb5_containers(self, secrets):
         """Add krb5 init and renew containers for a job."""
-        krb5_config = get_kerberos_k8s_config(
+        krb5_config = _get_compatible_kerberos_k8s_config(
             secrets,
             kubernetes_uid=self.kubernetes_uid,
         )
@@ -596,11 +666,9 @@ class KubernetesJobManager(JobManager):
                         echo "[ERROR] VOMSPROXY_FILE {voms_proxy_user_file} does not exist in user secrets."; \
                         exit; \
                      fi; \
-                     cp /etc/reana/secrets/{voms_proxy_user_file} {voms_proxy_file_path}; \
-                     chown {kubernetes_uid} {voms_proxy_file_path}'.format(
+                     cp /etc/reana/secrets/{voms_proxy_user_file} {voms_proxy_file_path}'.format(
                         voms_proxy_user_file=voms_proxy_user_file,
                         voms_proxy_file_path=voms_proxy_file_path,
-                        kubernetes_uid=self.kubernetes_uid,
                     ),
                 ],
                 "name": current_app.config["VOMSPROXY_CONTAINER_NAME"],
@@ -608,6 +676,10 @@ class KubernetesJobManager(JobManager):
                 "volumeMounts": [secrets_volume_mount] + volume_mounts,
                 "env": secret_env_vars,
             }
+            if K8S_USE_SECURITY_CONTEXT:
+                voms_proxy_container["securityContext"] = (
+                    _restricted_container_security_context(self.kubernetes_uid)
+                )
         else:
             # single-user deployment mode, where we generate VOMS proxy file in the sidecar from user secrets
             voms_proxy_container = {
@@ -636,11 +708,9 @@ class KubernetesJobManager(JobManager):
                          echo $VOMSPROXY_PASS | base64 -d | voms-proxy-init \
                          --voms {voms_proxy_vo} --key /tmp/userkey.pem \
                          --cert $(readlink -f /etc/reana/secrets/usercert.pem) \
-                         --pwstdin --out {voms_proxy_file_path}; \
-                         chown {kubernetes_uid} {voms_proxy_file_path}'.format(
+                         --pwstdin --out {voms_proxy_file_path}'.format(
                         voms_proxy_vo=voms_proxy_vo.lower(),
                         voms_proxy_file_path=voms_proxy_file_path,
-                        kubernetes_uid=self.kubernetes_uid,
                     ),
                 ],
                 "name": current_app.config["VOMSPROXY_CONTAINER_NAME"],
@@ -648,6 +718,10 @@ class KubernetesJobManager(JobManager):
                 "volumeMounts": [secrets_volume_mount] + volume_mounts,
                 "env": secret_env_vars,
             }
+            if K8S_USE_SECURITY_CONTEXT:
+                voms_proxy_container["securityContext"] = (
+                    _restricted_container_security_context(self.kubernetes_uid)
+                )
 
         self.job["spec"]["template"]["spec"]["volumes"].extend([ticket_cache_volume])
         self.job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"].extend(
@@ -731,6 +805,10 @@ class KubernetesJobManager(JobManager):
             "volumeMounts": [secrets_volume_mount] + volume_mounts,
             "env": secret_env_vars,
         }
+        if K8S_USE_SECURITY_CONTEXT:
+            rucio_config_container["securityContext"] = (
+                _restricted_container_security_context(self.kubernetes_uid)
+            )
 
         self.job["spec"]["template"]["spec"]["volumes"].extend([ticket_cache_volume])
         self.job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"].extend(
@@ -748,17 +826,18 @@ class KubernetesJobManager(JobManager):
     def set_user_id(self, kubernetes_uid):
         """Set UID for job pods.
 
-        UIDs below the cluster-configured minimum
-        (``REANA_KUBERNETES_JOBS_MIN_USER_UID``) are refused for security.
+        UIDs below the cluster-configured minimum are refused for security.
         """
         if kubernetes_uid is None:
-            self.kubernetes_uid = WORKFLOW_RUNTIME_USER_UID
+            self.kubernetes_uid = int(WORKFLOW_RUNTIME_USER_UID)
             return
-        if kubernetes_uid < REANA_KUBERNETES_JOBS_MIN_USER_UID:
+
+        kubernetes_uid = int(kubernetes_uid)
+        min_user_uid = int(REANA_KUBERNETES_JOBS_MIN_USER_UID)
+        if kubernetes_uid < min_user_uid:
             msg = (
                 f'The "kubernetes_uid" requested ({kubernetes_uid}) is below '
-                f"the cluster-configured minimum "
-                f"({REANA_KUBERNETES_JOBS_MIN_USER_UID})."
+                f"the minimum allowed UID ({min_user_uid})."
             )
             raise REANAKubernetesUIDBelowMinimum(msg)
         self.kubernetes_uid = kubernetes_uid

--- a/reana_job_controller/nss_wrapper.py
+++ b/reana_job_controller/nss_wrapper.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Bootstrap nss_wrapper before starting the job controller."""
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_GROUP_NAME = "root"
+DEFAULT_HOME = "/tmp/reana-job-controller"
+DEFAULT_SHELL = "/bin/bash"
+DEFAULT_USER_NAME = "reana"
+FALLBACK_HOME_ROOT = Path("/tmp/reana-job-controller")
+FLASK_DEBUG_VALUES = {"1", "true"}
+GROUP_SOURCE = Path("/etc/group")
+PASSWD_SOURCE = Path("/etc/passwd")
+UWSGI_CONFIG_PATH = Path("/var/reana/uwsgi/uwsgi.ini")
+
+K8S_USE_SECURITY_CONTEXT_ENV = "K8S_USE_SECURITY_CONTEXT"
+LIBNSS_WRAPPER_PATH_ENV = "LIBNSS_WRAPPER_PATH"
+NSS_WRAPPER_GROUP_ENV = "NSS_WRAPPER_GROUP"
+NSS_WRAPPER_PASSWD_ENV = "NSS_WRAPPER_PASSWD"
+WORKFLOW_RUNTIME_GROUP_NAME_ENV = "WORKFLOW_RUNTIME_GROUP_NAME"
+WORKFLOW_RUNTIME_USER_GID_ENV = "WORKFLOW_RUNTIME_USER_GID"
+WORKFLOW_RUNTIME_USER_NAME_ENV = "WORKFLOW_RUNTIME_USER_NAME"
+WORKFLOW_RUNTIME_USER_UID_ENV = "WORKFLOW_RUNTIME_USER_UID"
+
+
+class NSSWrapperSetupError(RuntimeError):
+    """Raised when the nss_wrapper runtime contract cannot be fulfilled."""
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    """Identity that the job controller should expose via nss_wrapper."""
+
+    user_name: str
+    group_name: str
+    uid: int
+    gid: int
+    home: str
+    shell: str
+
+
+def _get_required_env(name):
+    """Get a required environment variable."""
+    value = os.getenv(name)
+    if not value:
+        raise NSSWrapperSetupError(f"Environment variable {name} is not set.")
+    return value
+
+
+def _using_security_context():
+    """Return whether Kubernetes security contexts are enabled."""
+    return os.getenv(K8S_USE_SECURITY_CONTEXT_ENV, "True").lower() == "true"
+
+
+def _resolve_runtime_home(uid):
+    """Return a writable home directory for the current runtime identity."""
+    preferred_home = Path(os.getenv("HOME", DEFAULT_HOME))
+    candidate_paths = [preferred_home]
+    fallback_home = FALLBACK_HOME_ROOT / str(uid)
+    if fallback_home != preferred_home:
+        candidate_paths.append(fallback_home)
+
+    for candidate in candidate_paths:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".reana-write-test"
+            probe.write_text("")
+            probe.unlink()
+            return str(candidate)
+        except OSError:
+            continue
+
+    raise NSSWrapperSetupError(
+        "Could not create a writable runtime home directory under "
+        f"{preferred_home} or {fallback_home}."
+    )
+
+
+def get_runtime_identity():
+    """Resolve the runtime identity for the synthetic NSS entries."""
+    user_name = os.getenv("CERN_USER") or os.getenv(
+        WORKFLOW_RUNTIME_USER_NAME_ENV, DEFAULT_USER_NAME
+    )
+    if not user_name:
+        raise NSSWrapperSetupError(
+            "Could not determine workflow username from CERN_USER "
+            f"or {WORKFLOW_RUNTIME_USER_NAME_ENV}."
+        )
+
+    if _using_security_context():
+        uid = int(_get_required_env(WORKFLOW_RUNTIME_USER_UID_ENV))
+        gid = int(_get_required_env(WORKFLOW_RUNTIME_USER_GID_ENV))
+        group_name = os.getenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, DEFAULT_GROUP_NAME)
+    else:
+        uid = os.getuid()
+        gid = os.getgid()
+        configured_group_name = os.getenv(
+            WORKFLOW_RUNTIME_GROUP_NAME_ENV, DEFAULT_GROUP_NAME
+        )
+        group_name = (
+            user_name
+            if configured_group_name == DEFAULT_GROUP_NAME and gid != 0
+            else configured_group_name
+        )
+
+    return RuntimeIdentity(
+        user_name=user_name,
+        group_name=group_name,
+        uid=uid,
+        gid=gid,
+        home=_resolve_runtime_home(uid),
+        shell=DEFAULT_SHELL,
+    )
+
+
+def _build_passwd_contents(base_contents, identity):
+    """Merge the workflow user into passwd contents."""
+    desired_entry = (
+        f"{identity.user_name}:x:{identity.uid}:{identity.gid}:"
+        f"{identity.user_name}:{identity.home}:{identity.shell}"
+    )
+    desired_uid = str(identity.uid)
+    merged_lines = []
+    replaced = False
+    for line in base_contents.splitlines():
+        fields = line.split(":")
+        if len(fields) >= 7 and (
+            fields[0] == identity.user_name or fields[2] == desired_uid
+        ):
+            if not replaced:
+                merged_lines.append(desired_entry)
+                replaced = True
+            continue
+        merged_lines.append(line)
+    if not replaced:
+        merged_lines.append(desired_entry)
+    return "\n".join(merged_lines) + "\n"
+
+
+def _build_group_contents(base_contents, identity):
+    """Merge the workflow group into group contents."""
+    desired_entry = f"{identity.group_name}:x:{identity.gid}:"
+    desired_gid = str(identity.gid)
+    merged_lines = []
+    replaced = False
+    for line in base_contents.splitlines():
+        fields = line.split(":")
+        if len(fields) >= 4 and fields[2] == desired_gid:
+            if not replaced:
+                merged_lines.append(desired_entry)
+                replaced = True
+            continue
+        merged_lines.append(line)
+    if not replaced:
+        merged_lines.append(desired_entry)
+    return "\n".join(merged_lines) + "\n"
+
+
+def bootstrap_nss_wrapper():
+    """Materialize passwd/group files and set nss_wrapper environment."""
+    passwd_target = Path(_get_required_env(NSS_WRAPPER_PASSWD_ENV))
+    group_target = Path(_get_required_env(NSS_WRAPPER_GROUP_ENV))
+    library_path = Path(_get_required_env(LIBNSS_WRAPPER_PATH_ENV))
+    identity = get_runtime_identity()
+    home_path = Path(identity.home)
+    cache_path = home_path / ".cache"
+    condor_path = home_path / ".condor"
+
+    if not library_path.is_file():
+        raise NSSWrapperSetupError(
+            f"libnss_wrapper shared library does not exist: {library_path}"
+        )
+
+    try:
+        home_path.mkdir(parents=True, exist_ok=True)
+        cache_path.mkdir(parents=True, exist_ok=True)
+        condor_path.mkdir(parents=True, exist_ok=True)
+        passwd_target.parent.mkdir(parents=True, exist_ok=True)
+        group_target.parent.mkdir(parents=True, exist_ok=True)
+        passwd_contents = _build_passwd_contents(
+            PASSWD_SOURCE.read_text(), identity=identity
+        )
+        group_contents = _build_group_contents(
+            GROUP_SOURCE.read_text(), identity=identity
+        )
+        passwd_target.write_text(passwd_contents)
+        group_target.write_text(group_contents)
+    except OSError as exc:
+        raise NSSWrapperSetupError(
+            "Failed to materialize nss_wrapper passwd/group files under "
+            f"{passwd_target.parent}: {exc}"
+        ) from exc
+
+    os.environ["LD_PRELOAD"] = str(library_path)
+    os.environ["NSS_WRAPPER_PASSWD"] = str(passwd_target)
+    os.environ["NSS_WRAPPER_GROUP"] = str(group_target)
+    os.environ["USER"] = identity.user_name
+    os.environ["HOME"] = identity.home
+    os.environ["XDG_CACHE_HOME"] = str(cache_path)
+
+    return identity
+
+
+def _get_server_command():
+    """Select the job-controller server command for the current runtime."""
+    flask_debug = os.getenv("FLASK_DEBUG", "").lower() in FLASK_DEBUG_VALUES
+    if flask_debug:
+        return ["flask", "run", "-h", "0.0.0.0"]
+    if UWSGI_CONFIG_PATH.is_file():
+        return ["uwsgi", "--ini", str(UWSGI_CONFIG_PATH)]
+    LOGGER.info(
+        "uwsgi config %s was not found, falling back to the Flask development "
+        "server.",
+        UWSGI_CONFIG_PATH,
+    )
+    return ["flask", "run", "-h", "0.0.0.0"]
+
+
+def main():
+    """Bootstrap nss_wrapper and exec the selected job-controller server."""
+    logging.basicConfig(level=logging.INFO)
+    try:
+        identity = bootstrap_nss_wrapper()
+    except NSSWrapperSetupError as exc:
+        LOGGER.error("Failed to bootstrap nss_wrapper: %s", exc)
+        return 1
+
+    LOGGER.info(
+        "Starting job controller with nss_wrapper identity %s (%s:%s).",
+        identity.user_name,
+        identity.uid,
+        identity.gid,
+    )
+    command = _get_server_command()
+    LOGGER.info("Starting job controller via %s.", command[0])
+    try:
+        os.execvp(command[0], command)
+    except OSError as exc:
+        LOGGER.error("Failed to exec %s: %s", command[0], exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -8,17 +8,20 @@
 
 """REANA-Job-Controller Job Manager tests."""
 
+import base64
 import json
 import uuid
+from types import SimpleNamespace
 
 import mock
 import pytest
-from reana_db.models import Job, JobStatus
 from reana_commons.config import (
     KRB5_INIT_CONTAINER_NAME,
     KRB5_RENEW_CONTAINER_NAME,
+    WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_UID,
 )
+from reana_db.models import Job, JobStatus
 from reana_commons.errors import (
     REANAKubernetesCPULimitExceeded,
     REANAKubernetesWrongCPUFormat,
@@ -27,7 +30,18 @@ from reana_commons.errors import (
     REANAKubernetesWrongMemoryFormat,
 )
 from reana_job_controller.job_manager import JobManager
-from reana_job_controller.kubernetes_job_manager import KubernetesJobManager
+from reana_job_controller.kubernetes_job_manager import (
+    KubernetesJobManager,
+    _get_compatible_kerberos_k8s_config,
+)
+
+
+def _build_user_secret(value, secret_type):
+    """Build a mock Kubernetes user secret entry."""
+    return {
+        "value": base64.b64encode(value.encode()).decode(),
+        "type": secret_type,
+    }
 
 
 @pytest.mark.parametrize("kerberos", [False, True])
@@ -85,22 +99,252 @@ def test_execute_kubernetes_job(
             env_vars = containers[0]["env"]
             image = containers[0]["image"]
             command = containers[0]["args"]
+            container_security_context = containers[0]["securityContext"]
+            security_context = body["spec"]["template"]["spec"]["securityContext"]
             assert {"name": env_var_key, "value": env_var_value} in env_vars
             assert image == expected_image
+            assert security_context.run_as_user == int(WORKFLOW_RUNTIME_USER_UID)
+            assert security_context.run_as_group == int(WORKFLOW_RUNTIME_USER_GID)
+            assert container_security_context["runAsNonRoot"] is True
+            assert container_security_context["allowPrivilegeEscalation"] is False
+            assert container_security_context["capabilities"] == {"drop": ["ALL"]}
+            assert container_security_context["seccompProfile"] == {
+                "type": "RuntimeDefault"
+            }
             if kerberos:
                 assert len(containers) == 2  # main job + sidecar
                 assert len(init_containers) == 1
                 assert init_containers[0]["name"] == KRB5_INIT_CONTAINER_NAME
+                assert init_containers[0]["securityContext"] == {
+                    "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+                    "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+                    "runAsNonRoot": True,
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                }
                 assert len(env_vars) == 7  # KRB5CCNAME is added
                 assert "trap" in command[0] and expected_command in command[0]
                 assert "kinit -R" in containers[1]["args"][0]
                 assert containers[1]["name"] == KRB5_RENEW_CONTAINER_NAME
+                assert containers[1]["securityContext"] == {
+                    "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+                    "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+                    "runAsNonRoot": True,
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                }
             else:
                 assert len(containers) == 1
                 assert len(init_containers) == 0
                 # custom env + REANA_WORKSPACE + REANA_WORKFLOW_UUID + DASK_SCHEDULER_URI + two secrets
                 assert len(env_vars) == 6
                 assert command == [expected_command]
+
+
+def test_execute_kubernetes_job_with_voms_proxy_init_container(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that the VOMS init container is PSA-restricted."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    voms_user_secrets = {
+        "VOMSPROXY_FILE": _build_user_secret("proxy.pem", "env"),
+        "proxy.pem": _build_user_secret("proxy data", "file"),
+    }
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        voms_proxy=True,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(voms_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            init_container = body["spec"]["template"]["spec"]["initContainers"][0]
+
+            assert init_container["name"] == app.config["VOMSPROXY_CONTAINER_NAME"]
+            assert init_container["securityContext"] == {
+                "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+                "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+                "runAsNonRoot": True,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"drop": ["ALL"]},
+                "seccompProfile": {"type": "RuntimeDefault"},
+            }
+
+
+def test_execute_kubernetes_job_with_rucio_init_container(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that the Rucio init container is PSA-restricted."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    rucio_user_secrets = {
+        "VONAME": _build_user_secret("atlas", "env"),
+        "RUCIO_USERNAME": _build_user_secret("johndoe", "env"),
+    }
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+        rucio=True,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(rucio_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            init_container = body["spec"]["template"]["spec"]["initContainers"][0]
+
+            assert init_container["name"] == app.config["RUCIO_CONTAINER_NAME"]
+            assert init_container["securityContext"] == {
+                "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+                "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+                "runAsNonRoot": True,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {"drop": ["ALL"]},
+                "seccompProfile": {"type": "RuntimeDefault"},
+            }
+
+
+def test_execute_kubernetes_job_keeps_minimal_container_security_context_when_disabled(
+    app,
+    session,
+    sample_serial_workflow_in_db,
+    sample_workflow_workspace,
+    empty_user_secrets,
+    user0,
+    corev1_api_client_with_user_secrets,
+    monkeypatch,
+):
+    """Test that disabled security contexts still keep no-new-privileges on jobs."""
+    workflow_uuid = sample_serial_workflow_in_db.id_
+    workflow_workspace = next(sample_workflow_workspace(str(workflow_uuid)))
+    monkeypatch.setenv("REANA_USER_ID", str(user0.id_))
+    monkeypatch.setattr(
+        "reana_job_controller.kubernetes_job_manager.K8S_USE_SECURITY_CONTEXT",
+        False,
+    )
+    job_manager = KubernetesJobManager(
+        docker_img="docker.io/library/busybox",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid=workflow_uuid,
+        workflow_workspace=workflow_workspace,
+    )
+
+    with mock.patch(
+        "reana_job_controller.kubernetes_job_manager.current_k8s_batchv1_api_client"
+    ) as kubernetes_client:
+        with mock.patch(
+            "reana_commons.k8s.secrets.current_k8s_corev1_api_client",
+            corev1_api_client_with_user_secrets(empty_user_secrets),
+        ):
+            job_manager.execute()
+            body = kubernetes_client.create_namespaced_job.call_args[1]["body"]
+            job_spec = body["spec"]["template"]["spec"]
+
+            assert "securityContext" not in job_spec
+            assert job_spec["containers"][0]["securityContext"] == {
+                "allowPrivilegeEscalation": False
+            }
+
+
+def test_get_compatible_kerberos_k8s_config_supports_old_commons_api(monkeypatch):
+    """Retry Kerberos config calls without the new optional kwarg when needed."""
+    calls = []
+
+    def old_get_kerberos_k8s_config(secrets, kubernetes_uid):
+        calls.append((secrets, kubernetes_uid))
+        return "kerberos-config"
+
+    monkeypatch.setattr(
+        "reana_job_controller.kubernetes_job_manager.get_kerberos_k8s_config",
+        old_get_kerberos_k8s_config,
+    )
+
+    kerberos_config = _get_compatible_kerberos_k8s_config("secrets", 1000)
+
+    assert kerberos_config == "kerberos-config"
+    assert calls == [("secrets", 1000)]
+
+
+def test_get_compatible_kerberos_k8s_config_backfills_partial_security_context(
+    monkeypatch,
+):
+    """Backfill missing PSA fields from released commons Kerberos specs."""
+
+    def partially_hardened_get_kerberos_k8s_config(
+        secrets, kubernetes_uid, use_security_context=True
+    ):
+        return SimpleNamespace(
+            init_container={
+                "securityContext": {
+                    "runAsUser": int(kubernetes_uid),
+                    "runAsNonRoot": True,
+                }
+            },
+            renew_container={
+                "securityContext": {
+                    "runAsUser": int(kubernetes_uid),
+                    "runAsNonRoot": True,
+                }
+            },
+        )
+
+    monkeypatch.setattr(
+        "reana_job_controller.kubernetes_job_manager.get_kerberos_k8s_config",
+        partially_hardened_get_kerberos_k8s_config,
+    )
+
+    kerberos_config = _get_compatible_kerberos_k8s_config("secrets", 1000)
+
+    expected_security_context = {
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    assert (
+        kerberos_config.init_container["securityContext"] == expected_security_context
+    )
+    assert (
+        kerberos_config.renew_container["securityContext"] == expected_security_context
+    )
 
 
 def test_stop_kubernetes_job(
@@ -382,6 +626,7 @@ def test_set_memory_limit(
         (None, 100, False, WORKFLOW_RUNTIME_USER_UID),  # No UID: default.
         (50, 100, True, None),  # Below default minimum: refused.
         (500, 1000, True, None),  # Below admin-raised minimum: refused.
+        (1100, 1200, True, None),  # Below admin-raised minimum: refused.
         (0, 100, True, None),  # Root refused.
     ],
 )

--- a/tests/test_nss_wrapper.py
+++ b/tests/test_nss_wrapper.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for nss_wrapper bootstrap helpers."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from reana_job_controller.nss_wrapper import (
+    K8S_USE_SECURITY_CONTEXT_ENV,
+    LIBNSS_WRAPPER_PATH_ENV,
+    NSS_WRAPPER_GROUP_ENV,
+    NSS_WRAPPER_PASSWD_ENV,
+    NSSWrapperSetupError,
+    WORKFLOW_RUNTIME_GROUP_NAME_ENV,
+    WORKFLOW_RUNTIME_USER_GID_ENV,
+    WORKFLOW_RUNTIME_USER_NAME_ENV,
+    WORKFLOW_RUNTIME_USER_UID_ENV,
+    _get_server_command,
+    bootstrap_nss_wrapper,
+    get_runtime_identity,
+    main,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    """Restore process environment mutations performed by bootstrap_nss_wrapper()."""
+    original_environ = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(original_environ)
+
+
+def test_get_runtime_identity_uses_configured_ids(monkeypatch):
+    """Configured UID/GID should be used when security contexts are enabled."""
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "True")
+    monkeypatch.setenv("CERN_USER", "johndoe")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_UID_ENV, "1000")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_GID_ENV, "0")
+
+    identity = get_runtime_identity()
+
+    assert identity.user_name == "johndoe"
+    assert identity.group_name == "root"
+    assert identity.uid == 1000
+    assert identity.gid == 0
+
+
+def test_get_runtime_identity_uses_process_ids_when_security_context_disabled(
+    monkeypatch,
+):
+    """OpenShift-style deployments should derive the real runtime UID/GID."""
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "False")
+    monkeypatch.delenv("CERN_USER", raising=False)
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_NAME_ENV, "reana")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setattr("os.getuid", lambda: 43210)
+    monkeypatch.setattr("os.getgid", lambda: 54321)
+
+    identity = get_runtime_identity()
+
+    assert identity.user_name == "reana"
+    assert identity.group_name == "reana"
+    assert identity.uid == 43210
+    assert identity.gid == 54321
+
+
+def test_bootstrap_nss_wrapper_materializes_files_and_sets_env(tmp_path, monkeypatch):
+    """Bootstrap should preserve base entries and add the workflow identity."""
+    passwd_source = tmp_path / "passwd.source"
+    group_source = tmp_path / "group.source"
+    passwd_target = tmp_path / "passwd"
+    group_target = tmp_path / "group"
+    libnss_wrapper = tmp_path / "libnss_wrapper.so"
+
+    passwd_source.write_text("root:x:0:0:root:/root:/bin/bash\n")
+    group_source.write_text("root:x:0:\n")
+    libnss_wrapper.write_text("placeholder")
+
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.PASSWD_SOURCE", passwd_source)
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.GROUP_SOURCE", group_source)
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "True")
+    monkeypatch.setenv("CERN_USER", "johndoe")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_UID_ENV, "1000")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_GID_ENV, "0")
+    monkeypatch.setenv(NSS_WRAPPER_PASSWD_ENV, str(passwd_target))
+    monkeypatch.setenv(NSS_WRAPPER_GROUP_ENV, str(group_target))
+    monkeypatch.setenv(LIBNSS_WRAPPER_PATH_ENV, str(libnss_wrapper))
+    monkeypatch.setenv("HOME", str(tmp_path / "runtime-home"))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+    identity = bootstrap_nss_wrapper()
+
+    assert identity.user_name == "johndoe"
+    passwd_contents = passwd_target.read_text()
+    group_contents = group_target.read_text()
+
+    assert "root:x:0:0:root:/root:/bin/bash" in passwd_contents
+    assert (
+        f"johndoe:x:1000:0:johndoe:{tmp_path / 'runtime-home'}:/bin/bash"
+        in passwd_contents
+    )
+    assert "root:x:0:" in group_target.read_text()
+    assert (
+        sum(line.startswith("johndoe:") for line in passwd_contents.splitlines()) == 1
+    )
+    assert sum(line.startswith("root:") for line in group_contents.splitlines()) == 1
+    assert os.environ["LD_PRELOAD"] == str(libnss_wrapper)
+
+
+def test_bootstrap_nss_wrapper_preserves_root_group_on_openshift_like_runtime(
+    tmp_path, monkeypatch
+):
+    """Arbitrary runtime GIDs must not rewrite the base root group entry."""
+    passwd_source = tmp_path / "passwd.source"
+    group_source = tmp_path / "group.source"
+    passwd_target = tmp_path / "passwd"
+    group_target = tmp_path / "group"
+    libnss_wrapper = tmp_path / "libnss_wrapper.so"
+
+    passwd_source.write_text("root:x:0:0:root:/root:/bin/bash\n")
+    group_source.write_text("root:x:0:\nusers:x:100:\n")
+    libnss_wrapper.write_text("placeholder")
+
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.PASSWD_SOURCE", passwd_source)
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.GROUP_SOURCE", group_source)
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "False")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_NAME_ENV, "reana")
+    monkeypatch.setenv(NSS_WRAPPER_PASSWD_ENV, str(passwd_target))
+    monkeypatch.setenv(NSS_WRAPPER_GROUP_ENV, str(group_target))
+    monkeypatch.setenv(LIBNSS_WRAPPER_PATH_ENV, str(libnss_wrapper))
+    monkeypatch.setenv("HOME", "/home/ubuntu")
+    monkeypatch.setattr("os.getuid", lambda: 43210)
+    monkeypatch.setattr("os.getgid", lambda: 54321)
+
+    identity = bootstrap_nss_wrapper()
+    group_contents = group_target.read_text()
+
+    assert identity.group_name == "reana"
+    assert "root:x:0:" in group_contents
+    assert "reana:x:54321:" in group_contents
+    assert sum(line.startswith("root:") for line in group_contents.splitlines()) == 1
+
+
+def test_get_runtime_identity_falls_back_to_tmp_home_when_home_is_not_writable(
+    tmp_path, monkeypatch
+):
+    """Use a tmp-backed runtime home when the configured HOME is not writable."""
+    fallback_home_root = tmp_path / "fallback-home"
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "False")
+    monkeypatch.setenv("HOME", "/proc/reana-unwritable-home")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_NAME_ENV, "reana")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr("os.getuid", lambda: 43210)
+    monkeypatch.setattr("os.getgid", lambda: 54321)
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper.FALLBACK_HOME_ROOT",
+        fallback_home_root,
+    )
+
+    identity = get_runtime_identity()
+
+    assert identity.home == str(fallback_home_root / "43210")
+
+
+def test_bootstrap_nss_wrapper_prepares_runtime_home_cache_dirs(tmp_path, monkeypatch):
+    """Bootstrap should materialize writable HOME, XDG cache, and condor dirs."""
+    passwd_source = tmp_path / "passwd.source"
+    group_source = tmp_path / "group.source"
+    passwd_target = tmp_path / "passwd"
+    group_target = tmp_path / "group"
+    libnss_wrapper = tmp_path / "libnss_wrapper.so"
+    fallback_home_root = tmp_path / "fallback-home"
+
+    passwd_source.write_text("root:x:0:0:root:/root:/bin/bash\n")
+    group_source.write_text("root:x:0:\n")
+    libnss_wrapper.write_text("placeholder")
+
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.PASSWD_SOURCE", passwd_source)
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.GROUP_SOURCE", group_source)
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper.FALLBACK_HOME_ROOT",
+        fallback_home_root,
+    )
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "False")
+    monkeypatch.setenv("HOME", "/proc/reana-unwritable-home")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_NAME_ENV, "reana")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setenv(NSS_WRAPPER_PASSWD_ENV, str(passwd_target))
+    monkeypatch.setenv(NSS_WRAPPER_GROUP_ENV, str(group_target))
+    monkeypatch.setenv(LIBNSS_WRAPPER_PATH_ENV, str(libnss_wrapper))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr("os.getuid", lambda: 43210)
+    monkeypatch.setattr("os.getgid", lambda: 54321)
+
+    identity = bootstrap_nss_wrapper()
+    home_path = Path(identity.home)
+
+    assert home_path == fallback_home_root / "43210"
+    assert home_path.is_dir()
+    assert (home_path / ".cache").is_dir()
+    assert (home_path / ".condor").is_dir()
+    assert os.environ["HOME"] == str(home_path)
+    assert os.environ["XDG_CACHE_HOME"] == str(home_path / ".cache")
+
+
+def test_bootstrap_nss_wrapper_fails_without_library(tmp_path, monkeypatch):
+    """Bootstrap should fail fast when the wrapper library is missing."""
+    passwd_source = tmp_path / "passwd.source"
+    group_source = tmp_path / "group.source"
+    passwd_target = tmp_path / "passwd"
+    group_target = tmp_path / "group"
+
+    passwd_source.write_text("root:x:0:0:root:/root:/bin/bash\n")
+    group_source.write_text("root:x:0:\n")
+
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.PASSWD_SOURCE", passwd_source)
+    monkeypatch.setattr("reana_job_controller.nss_wrapper.GROUP_SOURCE", group_source)
+    monkeypatch.setenv(K8S_USE_SECURITY_CONTEXT_ENV, "True")
+    monkeypatch.setenv("CERN_USER", "johndoe")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_GROUP_NAME_ENV, "root")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_UID_ENV, "1000")
+    monkeypatch.setenv(WORKFLOW_RUNTIME_USER_GID_ENV, "0")
+    monkeypatch.setenv(NSS_WRAPPER_PASSWD_ENV, str(passwd_target))
+    monkeypatch.setenv(NSS_WRAPPER_GROUP_ENV, str(group_target))
+    monkeypatch.setenv(
+        LIBNSS_WRAPPER_PATH_ENV, str(tmp_path / "missing-libnss_wrapper.so")
+    )
+
+    with pytest.raises(NSSWrapperSetupError, match="libnss_wrapper"):
+        bootstrap_nss_wrapper()
+
+
+def test_get_server_command_uses_flask_in_debug(monkeypatch):
+    """Debug mode should keep using the Flask development server."""
+    monkeypatch.setenv("FLASK_DEBUG", "true")
+
+    assert _get_server_command() == ["flask", "run", "-h", "0.0.0.0"]
+
+
+def test_get_server_command_uses_uwsgi_when_config_present(tmp_path, monkeypatch):
+    """Production mode should use uwsgi when the mounted config is present."""
+    uwsgi_config = tmp_path / "uwsgi.ini"
+    uwsgi_config.write_text("[uwsgi]\n")
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper.UWSGI_CONFIG_PATH", uwsgi_config
+    )
+
+    assert _get_server_command() == ["uwsgi", "--ini", str(uwsgi_config)]
+
+
+def test_get_server_command_falls_back_to_flask_without_uwsgi_config(monkeypatch):
+    """Standalone runs should fall back to Flask when the uwsgi config is absent."""
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper.UWSGI_CONFIG_PATH",
+        Path("/definitely/missing/uwsgi.ini"),
+    )
+
+    assert _get_server_command() == ["flask", "run", "-h", "0.0.0.0"]
+
+
+def test_main_returns_error_when_execvp_fails(monkeypatch, caplog):
+    """CLI entrypoint should log and return non-zero on exec failures."""
+    identity = type(
+        "Identity",
+        (),
+        {"user_name": "reana", "uid": 1000, "gid": 0},
+    )()
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper.bootstrap_nss_wrapper", lambda: identity
+    )
+    monkeypatch.setattr(
+        "reana_job_controller.nss_wrapper._get_server_command",
+        lambda: ["uwsgi", "--ini", "/tmp/uwsgi.ini"],
+    )
+
+    def failing_execvp(_, __):
+        raise OSError("missing binary")
+
+    monkeypatch.setattr("os.execvp", failing_execvp)
+    caplog.set_level("ERROR")
+
+    assert main() == 1
+    assert "Failed to exec uwsgi: missing binary" in caplog.text


### PR DESCRIPTION
Start the job-controller sidecar as the runtime user instead of root and bootstrap a matching passwd and group view with nss_wrapper.

This keeps the process identity in sync with the Kubernetes security context even when the base image does not ship a suitable passwd entry or writable home directory.

When explicit security contexts are enabled, user job containers also run with dropped capabilities and
RuntimeDefault seccomp. Workflow images that depend on extra capabilities or unconfined syscalls may need adjustment.