### PR TITLE
fix(slurmcern): restore Slurm job submission after Paramiko update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# check=skip=SecretsUsedInArgOrEnv
+# The skip above concerns NSS_WRAPPER_PASSWD, which holds a file path
+# for nss_wrapper, not a secret. The check cannot be skipped per line.
+
 # This file is part of REANA.
 # Copyright (C) 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -225,6 +225,9 @@ to align with Pod Security Standards "restricted" expectations.
 SLURM_HEADNODE_HOSTNAME = os.getenv("SLURM_HOSTNAME", "hpc-batch.cern.ch")
 """Hostname of SLURM head-node used for job management via SSH."""
 
+SLURM_HEADNODE_GSS_HOSTNAME = os.getenv("SLURM_GSS_HOSTNAME")
+"""Hostname of SLURM head-node Kerberos service principal used for SSH GSSAPI authentication."""
+
 SLURM_HEADNODE_PORT = os.getenv("SLURM_CLUSTER_PORT", "22")
 """Port of SLURM head node."""
 

--- a/reana_job_controller/config.py
+++ b/reana_job_controller/config.py
@@ -231,7 +231,7 @@ SLURM_HEADNODE_GSS_HOSTNAME = os.getenv("SLURM_GSS_HOSTNAME")
 SLURM_HEADNODE_PORT = os.getenv("SLURM_CLUSTER_PORT", "22")
 """Port of SLURM head node."""
 
-SLURM_PARTITION = os.getenv("SLURM_PARTITION", "inf-short")
+SLURM_PARTITION = os.getenv("SLURM_PARTITION", "photon")
 """Default slurm partition."""
 
 SLURM_JOB_TIMELIMIT = os.getenv("SLURM_JOB_TIMELIMIT", "60")

--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -25,7 +25,7 @@ class JobManager:
         docker_img="",
         cmd=[],
         prettified_cmd="",
-        env_vars={},
+        env_vars=None,
         workflow_uuid=None,
         workflow_workspace=None,
         job_name=None,
@@ -53,7 +53,7 @@ class JobManager:
         self.workflow_uuid = workflow_uuid
         self.workflow_workspace = workflow_workspace
         self.job_name = job_name
-        self.env_vars = self._extend_env_vars(env_vars)
+        self.env_vars = self._extend_env_vars(env_vars or {})
 
     def execution_hook(fn):
         """Add before execution hooks and DB operations."""

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -22,6 +22,7 @@ from reana_db.models import Job, JobStatus
 
 from reana_job_controller.config import (
     COMPUTE_BACKENDS,
+    SLURM_HEADNODE_GSS_HOSTNAME,
     SLURM_HEADNODE_HOSTNAME,
     SLURM_HEADNODE_PORT,
     SLURM_SSH_TIMEOUT,
@@ -454,6 +455,7 @@ class JobMonitorSlurmCERN(JobMonitor):
         """
         slurm_connection = SSHClient(
             hostname=SLURM_HEADNODE_HOSTNAME,
+            gss_host=SLURM_HEADNODE_GSS_HOSTNAME,
             port=SLURM_HEADNODE_PORT,
             timeout=SLURM_SSH_TIMEOUT,
             banner_timeout=SLURM_SSH_BANNER_TIMEOUT,

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -14,6 +14,7 @@ from stat import S_ISDIR
 from reana_job_controller.job_manager import JobManager
 from reana_job_controller.utils import SSHClient, initialize_krb5_token
 from reana_job_controller.config import (
+    SLURM_HEADNODE_GSS_HOSTNAME,
     SLURM_HEADNODE_HOSTNAME,
     SLURM_HEADNODE_PORT,
     SLURM_PARTITION,
@@ -124,6 +125,7 @@ class SlurmJobManagerCERN(JobManager):
         initialize_krb5_token(workflow_uuid=self.workflow_uuid)
         self.slurm_connection = SSHClient(
             hostname=SLURM_HEADNODE_HOSTNAME,
+            gss_host=SLURM_HEADNODE_GSS_HOSTNAME,
             port=SLURM_HEADNODE_PORT,
             timeout=SLURM_SSH_TIMEOUT,
             banner_timeout=SLURM_SSH_BANNER_TIMEOUT,

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -7,6 +7,7 @@
 """CERN Slurm Job Manager."""
 
 import base64
+import hashlib
 import logging
 import os
 import shlex
@@ -35,6 +36,11 @@ class SlurmJobManagerCERN(JobManager):
     """Absolute REANA workspace path."""
     SLURM_HOME_PATH = os.getenv("SLURM_HOME_PATH", "")
     """Default SLURM home path."""
+    SLURM_SIF_CACHE_RELATIVE_PATH = ".reana/sif-cache"
+    """SIF image cache directory, relative to the SLURM home path.
+
+    The cache lives outside job workspaces so that converted images are
+    shared between workflows and are never transferred back to REANA."""
 
     def __init__(
         self,
@@ -148,27 +154,62 @@ class SlurmJobManagerCERN(JobManager):
         return not any(img_type in self.docker_img for img_type in [".sif", "cvmfs"])
 
     def _pull_image(self):
-        """Pull a Docker image using Singularity."""
+        """Pull a Docker image into the shared per-user SIF cache.
+
+        Reuses previously converted images across workflows and serialises
+        concurrent pulls of the same image with flock. The image is pulled
+        into a hidden temporary file and moved into place, so an interrupted
+        pull is never mistaken for a complete image.
+        """
         if self.img_type_docker:
-            container_image = self._get_container()
+            cache_dir = self._get_image_cache_dir()
+            image_stem = self._get_image_file_stem()
+            image_file = f"{image_stem}.sif"
+            temp_file = f".{image_stem}.part.sif"
             pull_command = (
-                "test -f {container_image} || singularity pull {docker_image}"
+                "test -f {image_file} || "
+                "(rm -f {temp_file} && "
+                "singularity pull {temp_file} {docker_image} && "
+                "mv {temp_file} {image_file})"
             ).format(
-                container_image=shlex.quote(container_image),
+                image_file=shlex.quote(image_file),
+                temp_file=shlex.quote(temp_file),
                 docker_image=shlex.quote(f"docker://{self.docker_img}"),
             )
             self.slurm_connection.exec_command(
-                "cd {workspace} && flock {lock_file} sh -c {pull_command}".format(
-                    workspace=shlex.quote(self.SLURM_WORKSAPCE_PATH),
-                    lock_file=shlex.quote(f".{container_image}.lock"),
+                "mkdir -p {cache_dir} && cd {cache_dir} && "
+                "flock {lock_file} sh -c {pull_command}".format(
+                    cache_dir=shlex.quote(cache_dir),
+                    lock_file=shlex.quote(f".{image_stem}.lock"),
                     pull_command=shlex.quote(pull_command),
                 )
             )
 
+    def _get_image_cache_dir(self):
+        """Get the shared per-user SIF image cache directory on the Slurm side."""
+        return os.path.join(
+            self.slurm_home_path, SlurmJobManagerCERN.SLURM_SIF_CACHE_RELATIVE_PATH
+        )
+
+    def _get_image_file_stem(self):
+        """Get the cache file name stem for the job's Docker image.
+
+        The stem combines a human-readable image name with the SHA-256 digest
+        of the fully-qualified image reference including the registry, the
+        namespace and the tag, so that distinct references never clash in the
+        shared cache. Note that mutable tags such as ``latest`` are converted
+        on first use and are not refreshed afterwards.
+        """
+        readable_name = self.docker_img.split("/")[-1].replace(":", "_")
+        reference_digest = hashlib.sha256(self.docker_img.encode("utf-8")).hexdigest()
+        return f"{readable_name}-{reference_digest}"
+
     def _get_container(self):
-        """Get container image."""
+        """Get container image path for job execution."""
         if self.img_type_docker:
-            return self.docker_img.split("/")[-1].replace(":", "_") + ".sif"
+            return os.path.join(
+                self._get_image_cache_dir(), f"{self._get_image_file_stem()}.sif"
+            )
         return self.docker_img
 
     def _dump_job_submission_file(self):

--- a/reana_job_controller/slurmcern_job_manager.py
+++ b/reana_job_controller/slurmcern_job_manager.py
@@ -9,6 +9,7 @@
 import base64
 import logging
 import os
+import shlex
 from stat import S_ISDIR
 
 from reana_job_controller.job_manager import JobManager
@@ -149,8 +150,19 @@ class SlurmJobManagerCERN(JobManager):
     def _pull_image(self):
         """Pull a Docker image using Singularity."""
         if self.img_type_docker:
+            container_image = self._get_container()
+            pull_command = (
+                "test -f {container_image} || singularity pull {docker_image}"
+            ).format(
+                container_image=shlex.quote(container_image),
+                docker_image=shlex.quote(f"docker://{self.docker_img}"),
+            )
             self.slurm_connection.exec_command(
-                f"cd {self.SLURM_WORKSAPCE_PATH} && singularity pull docker://{self.docker_img}"
+                "cd {workspace} && flock {lock_file} sh -c {pull_command}".format(
+                    workspace=shlex.quote(self.SLURM_WORKSAPCE_PATH),
+                    lock_file=shlex.quote(f".{container_image}.lock"),
+                    pull_command=shlex.quote(pull_command),
+                )
             )
 
     def _get_container(self):

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -226,12 +226,19 @@ class SSHClient:
         banner_timeout=None,
         auth_timeout=None,
         auth_strategy=None,
+        gss_host=None,
     ):
         """Initialize ssh client."""
+        self.gss_host = gss_host or hostname
         if hostname:
             # resolve IPv4 address of DNS load-balanced Slurm nodes to ease connection troubles
             try:
-                self.hostname = socket.gethostbyname_ex(hostname)[2][0]
+                resolved_hostname = socket.gethostbyname_ex(hostname)[2][0]
+                self.hostname = resolved_hostname
+                if not gss_host:
+                    canonical_hostname = socket.getfqdn(resolved_hostname)
+                    if canonical_hostname != resolved_hostname:
+                        self.gss_host = canonical_hostname
             except Exception:
                 self.hostname = hostname
         else:
@@ -254,8 +261,8 @@ class SSHClient:
             auth_timeout=self.auth_timeout,
             banner_timeout=self.banner_timeout,
             gss_auth=True,
-            gss_host=self.hostname,
-            gss_trust_dns=True,
+            gss_host=self.gss_host,
+            gss_trust_dns=False,
             look_for_keys=False,
             port=self.port,
             timeout=self.timeout,

--- a/reana_job_controller/utils.py
+++ b/reana_job_controller/utils.py
@@ -283,3 +283,4 @@ class SSHClient:
                 "Exception while executing cmd: {} \n{}".format(command, str(e)),
                 exc_info=True,
             )
+            raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,12 +24,14 @@ charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
 click==8.4.1              # via flask, reana-commons
 cryptography==48.0.0      # via paramiko, sqlalchemy-utils
+decorator==5.3.1          # via gssapi
 durationpy==0.10          # via kubernetes
 flask==3.1.3              # via reana-job-controller (setup.py)
 frozenlist==1.8.0         # via aiohttp, aiosignal
 fs==2.4.16                # via reana-commons, reana-job-controller (setup.py)
 gherkin-official==39.1.0  # via reana-commons
 greenlet==3.5.1           # via sqlalchemy
+gssapi==1.11.1            # via paramiko
 idna==3.18                # via jsonschema, requests, yarl
 importlib-resources==7.1.0  # via swagger-spec-validator
 invoke==3.0.3             # via paramiko
@@ -50,10 +52,11 @@ msgpack-python==0.5.6     # via bravado
 multidict==6.7.1          # via aiohttp, yarl
 oauthlib==3.3.1           # via requests-oauthlib
 packaging==26.2           # via apispec, kombu, marshmallow
-paramiko[gssapi]==5.0.0   # via reana-job-controller (setup.py)
+paramiko[gssapi]==4.0.0   # via reana-job-controller (setup.py)
 parse==1.22.1             # via reana-commons
 propcache==0.5.2          # via aiohttp, yarl
 psycopg2-binary==2.9.12   # via reana-db
+pyasn1==0.6.3             # via paramiko
 pycparser==3.0            # via cffi
 pynacl==1.6.2             # via paramiko
 pyrsistent==0.20.0        # via jsonschema

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -206,7 +206,7 @@ all_darwin() {
     ./run-tests.sh --docs-openapi &&
     ./run-tests.sh --docs-sphinx &&
     pytest"
-    docker run -v "$(pwd)"/..:/code -ti $DOCKER_IMAGE_NAME bash -c "eval $RUN_TESTS_INSIDE_DOCKER"
+    docker run --user root -v "$(pwd)"/..:/code -ti $DOCKER_IMAGE_NAME bash -c "eval $RUN_TESTS_INSIDE_DOCKER"
     stop_db_container
 }
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ extras_require = {
         "reana-commons[kubernetes,tests]>=0.95.0a20,<0.96.0",
         "reana-db[tests]>=0.95.0a10,<0.96.0",
     ],
-    "ssh": ["paramiko[gssapi]>=3.2.0"],
+    # NOTE: Paramiko 5 removed GSSAPI/Kerberos support, which the SlurmCERN
+    # backend needs for gss_auth SSH to the Slurm head node. Keep Paramiko
+    # below 5 until the SlurmCERN transport migrates to asyncssh.
+    "ssh": ["paramiko[gssapi]>=3.2.0,<5.0"],
     "mytoken": [
         "pyjwt>=2.8.0",
         "libmytoken>=0.1.0",

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -34,6 +34,7 @@ from reana_job_controller.kubernetes_job_manager import (
     KubernetesJobManager,
     _get_compatible_kerberos_k8s_config,
 )
+from reana_job_controller.slurmcern_job_manager import SlurmJobManagerCERN
 
 
 def _build_user_secret(value, secret_type):
@@ -141,6 +142,24 @@ def test_execute_kubernetes_job(
                 # custom env + REANA_WORKSPACE + REANA_WORKFLOW_UUID + DASK_SCHEDULER_URI + two secrets
                 assert len(env_vars) == 6
                 assert command == [expected_command]
+
+
+def test_slurm_pull_image_reuses_existing_container():
+    """Test Slurm Docker image pulls are idempotent."""
+    job_manager = SlurmJobManagerCERN(
+        docker_img="docker.io/reanahub/reana-env-root6:6.18.04",
+        cmd="root --version",
+    )
+    job_manager.slurm_connection = mock.MagicMock()
+    SlurmJobManagerCERN.SLURM_WORKSAPCE_PATH = "/remote/workspace"
+
+    job_manager._pull_image()
+
+    job_manager.slurm_connection.exec_command.assert_called_once_with(
+        "cd /remote/workspace && flock .reana-env-root6_6.18.04.sif.lock "
+        "sh -c 'test -f reana-env-root6_6.18.04.sif || "
+        "singularity pull docker://docker.io/reanahub/reana-env-root6:6.18.04'"
+    )
 
 
 def test_execute_kubernetes_job_with_voms_proxy_init_container(

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -623,7 +623,7 @@ def test_set_memory_limit(
         (1500, 100, False, 1500),  # UID well above minimum accepted as-is.
         (100, 100, False, 100),  # UID equal to minimum accepted.
         (1000, 1000, False, 1000),  # Accepted under admin-raised minimum.
-        (None, 100, False, WORKFLOW_RUNTIME_USER_UID),  # No UID: default.
+        (None, 100, False, int(WORKFLOW_RUNTIME_USER_UID)),  # No UID: default.
         (50, 100, True, None),  # Below default minimum: refused.
         (500, 1000, True, None),  # Below admin-raised minimum: refused.
         (1100, 1200, True, None),  # Below admin-raised minimum: refused.

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -145,21 +145,55 @@ def test_execute_kubernetes_job(
 
 
 def test_slurm_pull_image_reuses_existing_container():
-    """Test Slurm Docker image pulls are idempotent."""
+    """Test Slurm Docker image pulls populate the shared SIF cache idempotently."""
     job_manager = SlurmJobManagerCERN(
         docker_img="docker.io/reanahub/reana-env-root6:6.18.04",
         cmd="root --version",
     )
     job_manager.slurm_connection = mock.MagicMock()
-    SlurmJobManagerCERN.SLURM_WORKSAPCE_PATH = "/remote/workspace"
+    job_manager.slurm_home_path = "/slurmhome/johndoe"
+    stem = (
+        "reana-env-root6_6.18.04-"
+        "e589c4b1fa0f663994116d5a25c69d1a1bacab92f1764dfd82a8c5cfe8a37ada"
+    )
 
     job_manager._pull_image()
 
     job_manager.slurm_connection.exec_command.assert_called_once_with(
-        "cd /remote/workspace && flock .reana-env-root6_6.18.04.sif.lock "
-        "sh -c 'test -f reana-env-root6_6.18.04.sif || "
-        "singularity pull docker://docker.io/reanahub/reana-env-root6:6.18.04'"
+        "mkdir -p /slurmhome/johndoe/.reana/sif-cache && "
+        "cd /slurmhome/johndoe/.reana/sif-cache && "
+        f"flock .{stem}.lock "
+        f"sh -c 'test -f {stem}.sif || "
+        f"(rm -f .{stem}.part.sif && "
+        f"singularity pull .{stem}.part.sif "
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04 && "
+        f"mv .{stem}.part.sif {stem}.sif)'"
     )
+
+
+def test_slurm_container_image_uses_shared_cache_path():
+    """Test Slurm jobs execute images from the shared SIF cache."""
+    job_manager = SlurmJobManagerCERN(
+        docker_img="docker.io/reanahub/reana-env-root6:6.18.04",
+        cmd="root --version",
+    )
+    job_manager.slurm_home_path = "/slurmhome/johndoe"
+
+    assert job_manager._get_container() == (
+        "/slurmhome/johndoe/.reana/sif-cache/"
+        "reana-env-root6_6.18.04-"
+        "e589c4b1fa0f663994116d5a25c69d1a1bacab92f1764dfd82a8c5cfe8a37ada.sif"
+    )
+
+
+def test_slurm_image_cache_names_do_not_clash():
+    """Test that ambiguous image references map to distinct cache entries."""
+    stems = set()
+    for docker_img in ("docker.io/foo/bar_baz:1", "docker.io/foo_bar/baz:1"):
+        job_manager = SlurmJobManagerCERN(docker_img=docker_img, cmd="true")
+        stems.add(job_manager._get_image_file_stem())
+
+    assert len(stems) == 2
 
 
 def test_execute_kubernetes_job_with_voms_proxy_init_container(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 import logging
+from unittest import mock
+
 import pytest
 
+import reana_job_controller.utils as utils
 from reana_job_controller.utils import MultilineFormatter
 
 """REANA-Job-Controller utils tests."""
@@ -59,4 +62,125 @@ def test_multiline_formatter_format(message, expected_output):
             ),
         )
         == expected_output
+    )
+
+
+def test_ssh_client_uses_resolved_ipv4_for_connection_and_hostname_for_gss():
+    """Test SSHClient keeps hostname as Kerberos target when PTR is unavailable."""
+    ssh_client = mock.MagicMock()
+    paramiko_mock = mock.MagicMock()
+    paramiko_mock.SSHClient.return_value = ssh_client
+
+    with (
+        mock.patch.object(
+            utils.SSHClient.__closure__[0].cell_contents, "paramiko", paramiko_mock
+        ),
+        mock.patch.object(
+            utils.socket,
+            "gethostbyname_ex",
+            return_value=("slurm.example.org", [], ["10.0.0.10"]),
+        ),
+        mock.patch.object(utils.socket, "getfqdn", return_value="10.0.0.10"),
+    ):
+        utils.SSHClient.__closure__[1].cell_contents.clear()
+        try:
+            utils.SSHClient(hostname="slurm.example.org", port=22)
+        finally:
+            utils.SSHClient.__closure__[1].cell_contents.clear()
+
+    ssh_client.connect.assert_called_once_with(
+        hostname="10.0.0.10",
+        allow_agent=False,
+        auth_timeout=None,
+        banner_timeout=None,
+        gss_auth=True,
+        gss_host="slurm.example.org",
+        gss_trust_dns=False,
+        look_for_keys=False,
+        port=22,
+        timeout=None,
+        auth_strategy=None,
+    )
+
+
+def test_ssh_client_uses_reverse_dns_name_for_gss_when_available():
+    """Test SSHClient uses selected IPv4 PTR name as Kerberos target."""
+    ssh_client = mock.MagicMock()
+    paramiko_mock = mock.MagicMock()
+    paramiko_mock.SSHClient.return_value = ssh_client
+
+    with (
+        mock.patch.object(
+            utils.SSHClient.__closure__[0].cell_contents, "paramiko", paramiko_mock
+        ),
+        mock.patch.object(
+            utils.socket,
+            "gethostbyname_ex",
+            return_value=("slurm.example.org", [], ["10.0.0.11"]),
+        ),
+        mock.patch.object(
+            utils.socket, "getfqdn", return_value="slurmgate01.example.org"
+        ),
+    ):
+        utils.SSHClient.__closure__[1].cell_contents.clear()
+        try:
+            utils.SSHClient(hostname="slurm.example.org", port=22)
+        finally:
+            utils.SSHClient.__closure__[1].cell_contents.clear()
+
+    ssh_client.connect.assert_called_once_with(
+        hostname="10.0.0.11",
+        allow_agent=False,
+        auth_timeout=None,
+        banner_timeout=None,
+        gss_auth=True,
+        gss_host="slurmgate01.example.org",
+        gss_trust_dns=False,
+        look_for_keys=False,
+        port=22,
+        timeout=None,
+        auth_strategy=None,
+    )
+
+
+def test_ssh_client_prefers_explicit_gss_host():
+    """Test SSHClient supports overriding the Kerberos target."""
+    ssh_client = mock.MagicMock()
+    paramiko_mock = mock.MagicMock()
+    paramiko_mock.SSHClient.return_value = ssh_client
+
+    with (
+        mock.patch.object(
+            utils.SSHClient.__closure__[0].cell_contents, "paramiko", paramiko_mock
+        ),
+        mock.patch.object(
+            utils.socket,
+            "gethostbyname_ex",
+            return_value=("slurm.example.org", [], ["10.0.0.11"]),
+        ),
+        mock.patch.object(utils.socket, "getfqdn") as getfqdn,
+    ):
+        utils.SSHClient.__closure__[1].cell_contents.clear()
+        try:
+            utils.SSHClient(
+                hostname="slurm.example.org",
+                gss_host="slurmgate04.example.org",
+                port=22,
+            )
+        finally:
+            utils.SSHClient.__closure__[1].cell_contents.clear()
+
+    getfqdn.assert_not_called()
+    ssh_client.connect.assert_called_once_with(
+        hostname="10.0.0.11",
+        allow_agent=False,
+        auth_timeout=None,
+        banner_timeout=None,
+        gss_auth=True,
+        gss_host="slurmgate04.example.org",
+        gss_trust_dns=False,
+        look_for_keys=False,
+        port=22,
+        timeout=None,
+        auth_strategy=None,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 
 import reana_job_controller.utils as utils
+from reana_job_controller.config import SLURM_PARTITION
 from reana_job_controller.utils import MultilineFormatter
 
 """REANA-Job-Controller utils tests."""
@@ -184,3 +185,32 @@ def test_ssh_client_prefers_explicit_gss_host():
         timeout=None,
         auth_strategy=None,
     )
+
+
+def test_ssh_client_exec_command_raises_remote_errors():
+    """Test SSHClient propagates command execution failures."""
+    ssh_client = mock.MagicMock()
+    ssh_client.get_transport.return_value.active = True
+    stdout = mock.MagicMock()
+    stdout.channel.recv_exit_status.return_value = 1
+    stderr = mock.MagicMock()
+    stderr.read.return_value = b"remote command failed"
+    ssh_client.exec_command.return_value = (mock.MagicMock(), stdout, stderr)
+    paramiko_mock = mock.MagicMock()
+    paramiko_mock.SSHClient.return_value = ssh_client
+
+    with mock.patch.object(
+        utils.SSHClient.__closure__[0].cell_contents, "paramiko", paramiko_mock
+    ):
+        utils.SSHClient.__closure__[1].cell_contents.clear()
+        try:
+            client = utils.SSHClient(hostname="slurm.example.org", port=22)
+            with pytest.raises(Exception, match="remote command failed"):
+                client.exec_command("failing command")
+        finally:
+            utils.SSHClient.__closure__[1].cell_contents.clear()
+
+
+def test_slurm_partition_uses_current_cern_default():
+    """Test default Slurm partition follows the current CERN cluster."""
+    assert SLURM_PARTITION == "photon"


### PR DESCRIPTION
Closes reanahub/reana-job-controller#529.

This PR fixes SlurmCERN job submission after the Paramiko update.

The initial failure was caused by Paramiko 5 removing the legacy
`gss_auth` argument used by REANA's SSH connection setup. Pin Paramiko
below 5 until the SSH authentication path can be migrated to the newer
API.

The follow-up failure was caused by resolving the load-balanced Slurm
hostname to an IP address and then using that resolved value for GSSAPI
authentication. Keep the existing IPv4 connection workaround, but
preserve or derive the proper Kerberos service hostname for GSSAPI.
Add `SLURM_GSS_HOSTNAME` as an explicit override for environments where
DNS does not provide a suitable canonical hostname.

This PR also updates the default Slurm partition from the retired
`inf-short` queue to `photon`, and improves SSH command failure
handling so real `sbatch` errors are propagated instead of being hidden
behind a secondary `NoneType` failure.

Furthermore, Slurm container images are now materialised in a per-user
SIF cache directory located outside job workspaces, keyed by the SHA-256
digest of the fully-qualified image name, so that several steps or even
several workflows using the same Docker image convert it only once.
Keeping images out of the workspace also stops them from being
transferred back to REANA after each job and re-uploaded on the next
submission, which exceeded the uwsgi HTTP router 60-second timeout and
failed multi-step workflows such as the RooFit demo. Pulls are
serialised with `flock` to avoid races between parallel steps, and use
a temporary file moved into place so that interrupted pulls are never
mistaken for complete images.

Finally, the PR fixes a latent job-manager bug where instantiating a
job manager without environment variables crashed on a `None` default,
and includes small CI and test improvements (skipping a false-positive
Docker build secret check, running containerised tests as root on
macOS, expecting the default UID as integer).

Tested with end-to-end SlurmCERN submissions using several REANA
demo examples.