### PR TITLE
refactor(htcondorcern): migrate Python bindings to htcondor2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,23 +55,62 @@ RUN apt-get update -y && \
 
 # Default compute backend is Kubernetes
 ARG COMPUTE_BACKENDS=kubernetes
+ARG AUTHEN_KRB5_VERSION=1.906
+ARG AUTHEN_KRB5_SHA256=2dc0928efb13b5f305df3452088e63f92b67acea87fbd470308f460f79126e84
+
+COPY patches/Authen-Krb5-cc_copy_creds.patch /tmp/
 
 # Install CERN HTCondor compute backend dependencies (if necessary)
+# Prefer exact packages from stable after promotion. Keep QA as a temporary
+# fallback because the aarch64 packages are not available from stable yet.
 # hadolint ignore=DL3008,DL4006
-RUN if echo "$COMPUTE_BACKENDS" | grep -q "htcondorcern"; then \
+RUN set -e; \
+    if echo "$COMPUTE_BACKENDS" | grep -q "htcondorcern"; then \
       set -e; \
+      case "$TARGETARCH" in \
+        amd64) RPM_ARCH=x86_64 ;; \
+        arm64) RPM_ARCH=aarch64 ;; \
+        *) echo "Unsupported HTCondor target architecture: $TARGETARCH" >&2; exit 1 ;; \
+      esac; \
+      CERN_BATCH_STABLE_REPOSITORY="https://linuxsoft.cern.ch/internal/repos/batch9el-stable/$RPM_ARCH/os/Packages"; \
+      CERN_BATCH_QA_REPOSITORY="https://linuxsoft.cern.ch/internal/repos/batch9el-qa/$RPM_ARCH/os/Packages"; \
       apt-get update -y; \
-      apt-get install --no-install-recommends -y wget rpm2cpio cpio gnupg2 condor; \
-      wget -q -O ngbauth-submit.rpm https://linuxsoft.cern.ch/internal/repos/batch9al-stable/x86_64/os/Packages/n/ngbauth-submit-0.31-1.al9.cern.noarch.rpm; \
-      wget -q -O myschedd.rpm https://linuxsoft.cern.ch/internal/repos/batch9al-stable/x86_64/os/Packages/m/myschedd-1.9-2.al9.cern.x86_64.rpm; \
-      rpm2cpio /myschedd.rpm | cpio -idmv -D /; \
-      rpm2cpio /ngbauth-submit.rpm | cpio -idmv -D /; \
-      rm -f /myschedd.rpm /ngbauth-submit.rpm; \
-      apt-get remove -y gnupg2 wget rpm2cpio cpio; \
+      apt-get install --no-install-recommends -y wget rpm2cpio cpio gnupg2 condor cpanminus gcc make patch; \
+      wget -q -O /tmp/Authen-Krb5.tar.gz "https://cpan.metacpan.org/authors/id/O/OD/ODENBACH/Authen-Krb5-$AUTHEN_KRB5_VERSION.tar.gz"; \
+      echo "$AUTHEN_KRB5_SHA256  /tmp/Authen-Krb5.tar.gz" | sha256sum -c -; \
+      tar -xzf /tmp/Authen-Krb5.tar.gz -C /tmp; \
+      patch -d "/tmp/Authen-Krb5-$AUTHEN_KRB5_VERSION" -p1 < /tmp/Authen-Krb5-cc_copy_creds.patch; \
+      cpanm --notest --mirror https://cpan.metacpan.org --mirror-only "/tmp/Authen-Krb5-$AUTHEN_KRB5_VERSION"; \
+      perl -MAuthen::Krb5 -e 'die "cc_copy_creds is unavailable\n" unless Authen::Krb5->can("cc_copy_creds")'; \
+      if wget -q -O /ngbauth-submit.rpm "$CERN_BATCH_STABLE_REPOSITORY/n/ngbauth-submit-0.33-1.rh9.cern.noarch.rpm" && \
+          rpm2cpio /ngbauth-submit.rpm > /ngbauth-submit.cpio; then \
+        echo "Using ngbauth-submit from the stable repository."; \
+      else \
+        echo "Stable ngbauth-submit is unavailable or invalid; using QA."; \
+        wget -q -O /ngbauth-submit.rpm "$CERN_BATCH_QA_REPOSITORY/n/ngbauth-submit-0.33-1.rh9.cern.noarch.rpm"; \
+        rpm2cpio /ngbauth-submit.rpm > /ngbauth-submit.cpio; \
+      fi; \
+      if wget -q -O /myschedd.rpm "$CERN_BATCH_STABLE_REPOSITORY/m/myschedd-1.9-3.rh9.cern.$RPM_ARCH.rpm" && \
+          rpm2cpio /myschedd.rpm > /myschedd.cpio; then \
+        echo "Using myschedd from the stable repository."; \
+      else \
+        echo "Stable myschedd is unavailable or invalid; using QA."; \
+        wget -q -O /myschedd.rpm "$CERN_BATCH_QA_REPOSITORY/m/myschedd-1.9-3.rh9.cern.$RPM_ARCH.rpm"; \
+        rpm2cpio /myschedd.rpm > /myschedd.cpio; \
+      fi; \
+      cpio -idmv -D / < /myschedd.cpio; \
+      cpio -idmv -D / < /ngbauth-submit.cpio; \
+      rm -rf "/tmp/Authen-Krb5-$AUTHEN_KRB5_VERSION"; \
+      rm -f /tmp/Authen-Krb5.tar.gz /myschedd.rpm /myschedd.cpio /ngbauth-submit.rpm /ngbauth-submit.cpio; \
+      apt-get remove -y gnupg2 wget rpm2cpio cpio cpanminus gcc make patch; \
       apt-get autoremove -y; \
       apt-get clean; \
       rm -rf /var/lib/apt/lists/*; \
-    fi
+      test -x /usr/bin/myschedd; \
+      test -x /usr/bin/myschedd.sh; \
+      perl -T -c /usr/bin/batch_krb5_credential; \
+    fi; \
+    rm -f /tmp/Authen-Krb5-cc_copy_creds.patch
 
 # Copy Kerberos related configuration files
 COPY etc/krb5.conf /etc/krb5.conf

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -20,6 +20,7 @@ include docs/_static/reana-job-manager.xml
 exclude .readthedocs.yaml
 prune docs/_build
 recursive-include reana_job_controller *.json
+recursive-include patches *.patch
 recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.md

--- a/etc/myschedd.yaml
+++ b/etc/myschedd.yaml
@@ -9,6 +9,8 @@ pools:
     standard:
       - bigbird08.cern.ch
       - bigbird10.cern.ch
+      - bigbird101.cern.ch
+      - bigbird102.cern.ch
       - bigbird11.cern.ch
       - bigbird12.cern.ch
       - bigbird13.cern.ch
@@ -30,3 +32,7 @@ pools:
   spool:
     standard:
       - batfink02.cern.ch
+  eossubmit:
+    standard:
+      - bigbird103.cern.ch
+      - bigbird24.cern.ch

--- a/patches/Authen-Krb5-cc_copy_creds.patch
+++ b/patches/Authen-Krb5-cc_copy_creds.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/Authen/Krb5.xs b/lib/Authen/Krb5.xs
+index 3fa1e91..090782e 100644
+--- a/lib/Authen/Krb5.xs
++++ b/lib/Authen/Krb5.xs
+@@ -648,6 +648,16 @@ krb5_recvauth(auth_context,fh,version,server,keytab)
+ 	sv_setref_pv(ST(0),"Authen::Krb5::Ticket",(void*)ticket);
+ 	XSRETURN(1);
+ 
++void
++cc_copy_creds(incc,outcc)
++	Authen::Krb5::Ccache incc
++	Authen::Krb5::Ccache outcc
++
++	CODE:
++	err = krb5_cc_copy_creds(context, incc, outcc);
++	if (err) XSRETURN_UNDEF;
++	XSRETURN_YES;
++
+ 
+ MODULE = Authen::Krb5	PACKAGE = Authen::Krb5::Principal
+ 

--- a/patches/Authen-Krb5-cc_copy_creds.patch
+++ b/patches/Authen-Krb5-cc_copy_creds.patch
@@ -2,10 +2,7 @@ diff --git a/lib/Authen/Krb5.xs b/lib/Authen/Krb5.xs
 index 3fa1e91..090782e 100644
 --- a/lib/Authen/Krb5.xs
 +++ b/lib/Authen/Krb5.xs
-@@ -648,6 +648,16 @@ krb5_recvauth(auth_context,fh,version,server,keytab)
- 	sv_setref_pv(ST(0),"Authen::Krb5::Ticket",(void*)ticket);
- 	XSRETURN(1);
- 
+@@ -650,0 +651,10 @@ krb5_recvauth(auth_context,fh,version,server,keytab)
 +void
 +cc_copy_creds(incc,outcc)
 +	Authen::Krb5::Ccache incc
@@ -16,6 +13,3 @@ index 3fa1e91..090782e 100644
 +	if (err) XSRETURN_UNDEF;
 +	XSRETURN_YES;
 +
- 
- MODULE = Authen::Krb5	PACKAGE = Authen::Krb5::Principal
- 

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -13,7 +13,7 @@ import shlex
 import threading
 from shutil import copyfile
 
-import classad
+import classad2 as classad
 from flask import current_app
 from reana_db.database import Session
 from reana_db.models import Workflow
@@ -128,68 +128,82 @@ class HTCondorJobManagerCERN(JobManager):
         self.htcondor_request_disk = htcondor_request_disk
         self.htcondor_requirements = htcondor_requirements
 
-        # We need to import the htcondor package later during runtime after the Kerberos environment is fully initialised.
-        # Without a valid Kerberos ticket, importing will exit with "ERROR: Unauthorized 401 - do you have authentication tokens? Error "/usr/bin/myschedd.sh |"
+        # Import HTCondor only after initialising Kerberos. Importing the module
+        # evaluates the ``myschedd.sh`` configuration, which requires a valid
+        # ticket.
         initialize_krb5_token(workflow_uuid=self.workflow_uuid)
-        globals()["htcondor"] = __import__("htcondor")
+        globals()["htcondor"] = __import__("htcondor2")
 
     @JobManager.execution_hook
     def execute(self):
         """Execute / submit a job with HTCondor."""
         os.chdir(self.workflow_workspace)
-        job_ad = classad.ClassAd()
-        job_ad["JobDescription"] = (
-            self.workflow.get_full_workflow_name() + "_" + self.job_name
-        )
-        job_ad["JobMaxRetries"] = 3
-        job_ad["LeaveJobInQueue"] = classad.ExprTree(
-            "(JobStatus == 4) && ((StageOutFinish =?= UNDEFINED) || "
-            "(StageOutFinish == 0))"
-        )
-        job_ad["Cmd"] = (
+        executable = (
             "./job_wrapper.sh"
             if not self.unpacked_img
             else "./job_singularity_wrapper.sh"
         )
+        submit_description = {
+            "description": (
+                self.workflow.get_full_workflow_name() + "_" + self.job_name
+            ),
+            "MY.JobMaxRetries": "3",
+            "leave_in_queue": (
+                "(JobStatus == 4) && ((StageOutFinish =?= UNDEFINED) || "
+                "(StageOutFinish == 0))"
+            ),
+            "executable": executable,
+            "environment": self._format_env_vars(),
+            "output": "reana_job.$(ClusterId).$(ProcId).out",
+            "error": "reana_job.$(ClusterId).$(ProcId).err",
+            "should_transfer_files": "YES",
+            "when_to_transfer_output": "ON_EXIT",
+            "transfer_input_files": self._get_input_files(),
+            "transfer_output_files": ".",
+            "periodic_release": "(HoldReasonCode == 35)",
+        }
         if not self.unpacked_img:
-            job_ad["Arguments"] = self._format_arguments()
-            job_ad["DockerImage"] = self.docker_img
-            job_ad["WantDocker"] = True
-            job_ad["DockerNetworkType"] = "host"
-        job_ad["Environment"] = self._format_env_vars()
-        job_ad["Out"] = classad.ExprTree(
-            'strcat("reana_job.", ClusterId, ".", ProcId, ".out")'
-        )
-        job_ad["Err"] = classad.ExprTree(
-            'strcat("reana_job.", ClusterId, ".", ProcId, ".err")'
-        )
-        job_ad["log"] = classad.ExprTree('strcat("reana_job.", ClusterId, ".err")')
-        job_ad["ShouldTransferFiles"] = "YES"
-        job_ad["WhenToTransferOutput"] = "ON_EXIT"
-        job_ad["TransferInput"] = self._get_input_files()
-        job_ad["TransferOutput"] = "."
-        job_ad["PeriodicRelease"] = classad.ExprTree("(HoldReasonCode == 35)")
+            submit_description["arguments"] = self._format_arguments()
+            # Keep CERN's existing legacy Docker job attributes. Using the
+            # ``docker_image`` submit command would implicitly migrate these
+            # jobs to HTCondor's Container Universe.
+            submit_description["MY.DockerImage"] = classad.quote(self.docker_img)
+            submit_description["MY.WantDocker"] = "True"
+            submit_description["MY.DockerNetworkType"] = classad.quote("host")
         if self.htcondor_max_runtime in HTCONDOR_JOB_FLAVOURS.keys():
-            job_ad["JobFlavour"] = self.htcondor_max_runtime
+            submit_description["MY.JobFlavour"] = classad.quote(
+                self.htcondor_max_runtime
+            )
         elif str.isdigit(self.htcondor_max_runtime):
-            job_ad["MaxRunTime"] = int(self.htcondor_max_runtime)
+            submit_description["MY.MaxRunTime"] = self.htcondor_max_runtime
         else:
-            job_ad["MaxRunTime"] = 3600
+            submit_description["MY.MaxRunTime"] = "3600"
         if self.htcondor_accounting_group:
-            job_ad["AccountingGroup"] = self.htcondor_accounting_group
+            submit_description["MY.AccountingGroup"] = classad.quote(
+                self.htcondor_accounting_group
+            )
         if self.htcondor_request_cpus:
-            job_ad["RequestCpus"] = int(self.htcondor_request_cpus)
+            submit_description["request_cpus"] = self.htcondor_request_cpus
         if self.htcondor_request_memory:
-            job_ad["RequestMemory"] = htcondor_quantity_to_unit(
-                self.htcondor_request_memory, "M"
+            submit_description["request_memory"] = str(
+                htcondor_quantity_to_unit(self.htcondor_request_memory, "M")
             )
         if self.htcondor_request_disk:
-            job_ad["RequestDisk"] = htcondor_quantity_to_unit(
-                self.htcondor_request_disk, "K"
+            submit_description["request_disk"] = str(
+                htcondor_quantity_to_unit(self.htcondor_request_disk, "K")
             )
         if self.htcondor_requirements:
-            job_ad["Requirements"] = classad.ExprTree(self.htcondor_requirements)
-        future = current_app.htcondor_executor.submit(self._submit, job_ad)
+            # ``MY.Requirements`` preserves the existing behaviour where the
+            # supplied expression is the complete Requirements expression.
+            submit_description["MY.Requirements"] = self.htcondor_requirements
+        else:
+            # Prevent the submit engine from generating constraints for the
+            # submit host's architecture and operating system. The legacy
+            # raw-ClassAd submission did not add a Requirements expression.
+            submit_description["MY.Requirements"] = "True"
+        self._validate_submit_description(submit_description)
+        submit = htcondor.Submit(submit_description)  # noqa: F821
+        future = current_app.htcondor_executor.submit(self._submit, submit)
         clusterid = future.result()
         return clusterid
 
@@ -234,11 +248,24 @@ class HTCondorJobManagerCERN(JobManager):
         )
 
     def _format_env_vars(self):
-        """Return job env vars in job description format."""
-        job_env = ""
+        """Return job env vars in HTCondor's new environment syntax."""
+        entries = []
         for key, value in self.env_vars.items():
-            job_env += " {0}={1}".format(key, value)
-        return job_env
+            entry = "{0}={1}".format(key, value)
+            entry = entry.replace('"', '""').replace("'", "''")
+            entries.append("'{0}'".format(entry))
+        return '"{0}"'.format(" ".join(entries))
+
+    @staticmethod
+    def _validate_submit_description(submit_description):
+        """Reject values that could inject additional submit commands."""
+        forbidden_characters = ("\n", "\r", "\x00")
+        for command, value in submit_description.items():
+            if any(character in value for character in forbidden_characters):
+                raise ValueError(
+                    "HTCondor submit command {!r} contains a line break or "
+                    "null byte".format(command)
+                )
 
     def _get_workflow(self):
         """Get workflow from db."""
@@ -294,32 +321,45 @@ class HTCondorJobManagerCERN(JobManager):
             raise e
 
     @retry(stop_max_attempt_number=MAX_NUM_RETRIES, wait_fixed=RETRY_WAIT_TIME)
-    def _submit(self, job_ad):
+    def _submit(self, submit):
         """Execute submission transaction."""
-        ads = []
         schedd = HTCondorJobManagerCERN._get_schedd()
-        logging.info("Submiting job - {}".format(job_ad))
-        clusterid = schedd.submit(job_ad, 1, True, ads)
-        HTCondorJobManagerCERN._spool_input(ads)
-        return clusterid
+        logging.info("Submitting job - {}".format(submit))
+        result = schedd.submit(submit, count=1, spool=True)
+        HTCondorJobManagerCERN._spool_input(result)
+        return result.cluster()
 
+    @staticmethod
     @retry(stop_max_attempt_number=MAX_NUM_RETRIES, wait_fixed=RETRY_WAIT_TIME)
-    def _spool_input(ads):
+    def _spool_input(result):
         schedd = HTCondorJobManagerCERN._get_schedd()
-        logging.info("Spooling job inputs - {}".format(ads))
-        schedd.spool(ads)
+        logging.info("Spooling job inputs - {}".format(result))
+        schedd.spool(result)
 
+    @staticmethod
     @retry(stop_max_attempt_number=MAX_NUM_RETRIES, wait_fixed=RETRY_WAIT_TIME)
     def _get_schedd():
         """Find and return the HTCondor schedd."""
         schedd = getattr(thread_local, "MONITOR_THREAD_SCHEDD", None)
         if schedd is None:
-            setattr(
-                thread_local, "MONITOR_THREAD_SCHEDD", htcondor.Schedd()  # noqa: F821
+            schedd_host = htcondor.param.get("SCHEDD_HOST")  # noqa: F821
+            if not schedd_host:
+                raise RuntimeError("SCHEDD_HOST is not configured")
+
+            schedd_location = htcondor.Collector().locate(  # noqa: F821
+                htcondor.DaemonType.Schedd, schedd_host  # noqa: F821
             )
+            if schedd_location is None:
+                raise RuntimeError(
+                    "Unable to locate HTCondor schedd {}".format(schedd_host)
+                )
+
+            schedd = htcondor.Schedd(schedd_location)  # noqa: F821
+            setattr(thread_local, "MONITOR_THREAD_SCHEDD", schedd)
         logging.info("Getting schedd: {}".format(thread_local.MONITOR_THREAD_SCHEDD))
         return thread_local.MONITOR_THREAD_SCHEDD
 
+    @staticmethod
     def stop(backend_job_id):
         """Stop HTCondor job execution."""
         try:
@@ -331,6 +371,7 @@ class HTCondorJobManagerCERN(JobManager):
         except Exception as e:
             logging.error(e, exc_info=True)
 
+    @staticmethod
     @retry(stop_max_attempt_number=MAX_NUM_RETRIES, wait_fixed=RETRY_WAIT_TIME)
     def spool_output(backend_job_id):
         """Transfer job output."""
@@ -369,16 +410,12 @@ class HTCondorJobManagerCERN(JobManager):
             logging.error(msg, exc_info=True)
             return msg
 
+    @staticmethod
     def find_job_in_history(backend_job_id):
         """Return job if present in condor history."""
         schedd = HTCondorJobManagerCERN._get_schedd()
         ads = ["ClusterId", "JobStatus", "ExitCode", "RemoveReason"]
-        condor_it = schedd.history(
+        condor_jobs = schedd.history(
             "ClusterId == {0}".format(backend_job_id), ads, match=1
         )
-        try:
-            condor_job = next(condor_it)
-            return condor_job
-        except Exception:
-            # Did not match to any job in the history  yet
-            return None
+        return condor_jobs[0] if condor_jobs else None

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -7,9 +7,12 @@
 """CERN HTCondor Job Manager."""
 
 import base64
+import hashlib
 import logging
 import os
 import shlex
+import shutil
+import stat
 import threading
 from shutil import copyfile
 
@@ -29,6 +32,18 @@ thread_local = threading.local()
 
 class HTCondorJobManagerCERN(JobManager):
     """CERN HTCondor job management."""
+
+    FILE_TRANSFER_DIRECTORY_PREFIX = "reana_job."
+    FILE_TRANSFER_DIRECTORY_SUFFIX = ".filetransfer"
+    INTERNAL_OUTPUT_FILES = {
+        ".chirp.config",
+        ".job.ad",
+        ".machine.ad",
+        "_condor_stderr",
+        "_condor_stdout",
+        "condor_exec.exe",
+    }
+    INTERNAL_WORKFLOW_PATHS = {"yadage": {"_yadage"}}
 
     MAX_NUM_RETRIES = 3
     """Maximum number of tries used for getting schedd, job submission and
@@ -127,6 +142,16 @@ class HTCondorJobManagerCERN(JobManager):
         self.htcondor_request_memory = htcondor_request_memory
         self.htcondor_request_disk = htcondor_request_disk
         self.htcondor_requirements = htcondor_requirements
+        self.file_transfer_workspace = os.path.join(
+            self.workflow_workspace,
+            "{0}{1}{2}".format(
+                self.FILE_TRANSFER_DIRECTORY_PREFIX,
+                self.job_id,
+                self.FILE_TRANSFER_DIRECTORY_SUFFIX,
+            ),
+        )
+        self.input_file_signatures = {}
+        self.input_symlinks = set()
 
         # Import HTCondor only after initialising Kerberos. Importing the module
         # evaluates the ``myschedd.sh`` configuration, which requires a valid
@@ -138,74 +163,77 @@ class HTCondorJobManagerCERN(JobManager):
     def execute(self):
         """Execute / submit a job with HTCondor."""
         os.chdir(self.workflow_workspace)
-        executable = (
-            "./job_wrapper.sh"
-            if not self.unpacked_img
-            else "./job_singularity_wrapper.sh"
+        executable_name = (
+            "job_wrapper.sh" if not self.unpacked_img else "job_singularity_wrapper.sh"
         )
-        submit_description = {
-            "description": (
-                self.workflow.get_full_workflow_name() + "_" + self.job_name
-            ),
-            "MY.JobMaxRetries": "3",
-            "leave_in_queue": (
-                "(JobStatus == 4) && ((StageOutFinish =?= UNDEFINED) || "
-                "(StageOutFinish == 0))"
-            ),
-            "executable": executable,
-            "environment": self._format_env_vars(),
-            "output": "reana_job.$(ClusterId).$(ProcId).out",
-            "error": "reana_job.$(ClusterId).$(ProcId).err",
-            "should_transfer_files": "YES",
-            "when_to_transfer_output": "ON_EXIT",
-            "transfer_input_files": self._get_input_files(),
-            "transfer_output_files": ".",
-            "periodic_release": "(HoldReasonCode == 35)",
-        }
-        if not self.unpacked_img:
-            submit_description["arguments"] = self._format_arguments()
-            # Keep CERN's existing legacy Docker job attributes. Using the
-            # ``docker_image`` submit command would implicitly migrate these
-            # jobs to HTCondor's Container Universe.
-            submit_description["MY.DockerImage"] = classad.quote(self.docker_img)
-            submit_description["MY.WantDocker"] = "True"
-            submit_description["MY.DockerNetworkType"] = classad.quote("host")
-        if self.htcondor_max_runtime in HTCONDOR_JOB_FLAVOURS.keys():
-            submit_description["MY.JobFlavour"] = classad.quote(
-                self.htcondor_max_runtime
-            )
-        elif str.isdigit(self.htcondor_max_runtime):
-            submit_description["MY.MaxRunTime"] = self.htcondor_max_runtime
-        else:
-            submit_description["MY.MaxRunTime"] = "3600"
-        if self.htcondor_accounting_group:
-            submit_description["MY.AccountingGroup"] = classad.quote(
-                self.htcondor_accounting_group
-            )
-        if self.htcondor_request_cpus:
-            submit_description["request_cpus"] = self.htcondor_request_cpus
-        if self.htcondor_request_memory:
-            submit_description["request_memory"] = str(
-                htcondor_quantity_to_unit(self.htcondor_request_memory, "M")
-            )
-        if self.htcondor_request_disk:
-            submit_description["request_disk"] = str(
-                htcondor_quantity_to_unit(self.htcondor_request_disk, "K")
-            )
-        if self.htcondor_requirements:
-            # ``MY.Requirements`` preserves the existing behaviour where the
-            # supplied expression is the complete Requirements expression.
-            submit_description["MY.Requirements"] = self.htcondor_requirements
-        else:
-            # Prevent the submit engine from generating constraints for the
-            # submit host's architecture and operating system. The legacy
-            # raw-ClassAd submission did not add a Requirements expression.
-            submit_description["MY.Requirements"] = "True"
-        self._validate_submit_description(submit_description)
-        submit = htcondor.Submit(submit_description)  # noqa: F821
-        future = current_app.htcondor_executor.submit(self._submit, submit)
-        clusterid = future.result()
-        return clusterid
+        transfer_input_files = self._prepare_file_transfer()
+        try:
+            submit_description = {
+                "description": (
+                    self.workflow.get_full_workflow_name() + "_" + self.job_name
+                ),
+                "MY.JobMaxRetries": "3",
+                "leave_in_queue": (
+                    "(JobStatus == 4) && ((StageOutFinish =?= UNDEFINED) || "
+                    "(StageOutFinish == 0))"
+                ),
+                "initialdir": self.file_transfer_workspace,
+                "executable": os.path.join(self.workflow_workspace, executable_name),
+                "environment": self._format_env_vars(),
+                "output": "reana_job.$(ClusterId).$(ProcId).out",
+                "error": "reana_job.$(ClusterId).$(ProcId).err",
+                "should_transfer_files": "YES",
+                "when_to_transfer_output": "ON_EXIT",
+                "transfer_input_files": transfer_input_files,
+                "transfer_output_files": ".",
+                "periodic_release": "(HoldReasonCode == 35)",
+            }
+            if not self.unpacked_img:
+                submit_description["arguments"] = self._format_arguments()
+                # Keep CERN's existing legacy Docker job attributes. Using the
+                # ``docker_image`` submit command would implicitly migrate these
+                # jobs to HTCondor's Container Universe.
+                submit_description["MY.DockerImage"] = classad.quote(self.docker_img)
+                submit_description["MY.WantDocker"] = "True"
+                submit_description["MY.DockerNetworkType"] = classad.quote("host")
+            if self.htcondor_max_runtime in HTCONDOR_JOB_FLAVOURS.keys():
+                submit_description["MY.JobFlavour"] = classad.quote(
+                    self.htcondor_max_runtime
+                )
+            elif str.isdigit(self.htcondor_max_runtime):
+                submit_description["MY.MaxRunTime"] = self.htcondor_max_runtime
+            else:
+                submit_description["MY.MaxRunTime"] = "3600"
+            if self.htcondor_accounting_group:
+                submit_description["MY.AccountingGroup"] = classad.quote(
+                    self.htcondor_accounting_group
+                )
+            if self.htcondor_request_cpus:
+                submit_description["request_cpus"] = self.htcondor_request_cpus
+            if self.htcondor_request_memory:
+                submit_description["request_memory"] = str(
+                    htcondor_quantity_to_unit(self.htcondor_request_memory, "M")
+                )
+            if self.htcondor_request_disk:
+                submit_description["request_disk"] = str(
+                    htcondor_quantity_to_unit(self.htcondor_request_disk, "K")
+                )
+            if self.htcondor_requirements:
+                # ``MY.Requirements`` preserves the existing behaviour where the
+                # supplied expression is the complete Requirements expression.
+                submit_description["MY.Requirements"] = self.htcondor_requirements
+            else:
+                # Prevent the submit engine from generating constraints for the
+                # submit host's architecture and operating system. The legacy
+                # raw-ClassAd submission did not add a Requirements expression.
+                submit_description["MY.Requirements"] = "True"
+            self._validate_submit_description(submit_description)
+            submit = htcondor.Submit(submit_description)  # noqa: F821
+            future = current_app.htcondor_executor.submit(self._submit, submit)
+            return future.result()
+        except Exception:
+            self.cleanup_file_transfer()
+            raise
 
     def _replace_absolute_paths_with_relative(self, cmd):
         """Replace absolute with relative path."""
@@ -277,6 +305,219 @@ class HTCondorJobManagerCERN(JobManager):
         else:
             pass
 
+    @classmethod
+    def _is_file_transfer_directory(cls, name):
+        """Return whether a workspace entry is an HTCondor transfer directory."""
+        return name.startswith(cls.FILE_TRANSFER_DIRECTORY_PREFIX) and name.endswith(
+            cls.FILE_TRANSFER_DIRECTORY_SUFFIX
+        )
+
+    def _is_internal_workflow_path(self, relative_path):
+        """Return whether a path contains workflow-engine runtime state."""
+        workflow_type = getattr(self.workflow, "type_", None)
+        internal_paths = self.INTERNAL_WORKFLOW_PATHS.get(workflow_type, set())
+        top_level_path = relative_path.split(os.sep, 1)[0]
+        return top_level_path in internal_paths
+
+    def _exclude_internal_workflow_paths(self, root, entries, base_path):
+        """Return entries excluding workflow-engine runtime state paths."""
+        return [
+            entry
+            for entry in entries
+            if not self._is_internal_workflow_path(
+                os.path.relpath(os.path.join(root, entry), base_path)
+            )
+        ]
+
+    @staticmethod
+    def _hash_file(path):
+        """Return the SHA-256 digest of a file."""
+        digest = hashlib.sha256()
+        with open(path, "rb") as file_object:
+            for chunk in iter(lambda: file_object.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _file_signature(path):
+        """Return metadata that identifies a local workspace file."""
+        file_stat = os.stat(path, follow_symlinks=False)
+        return (
+            file_stat.st_dev,
+            file_stat.st_ino,
+            stat.S_IFMT(file_stat.st_mode),
+            file_stat.st_size,
+            file_stat.st_mtime_ns,
+            file_stat.st_ctime_ns,
+        )
+
+    @classmethod
+    def _files_equal(cls, first_path, second_path):
+        """Return whether two regular files have identical contents."""
+        if os.path.getsize(first_path) != os.path.getsize(second_path):
+            return False
+        return cls._hash_file(first_path) == cls._hash_file(second_path)
+
+    def _snapshot_workspace(self):
+        """Record workspace metadata before the HTCondor job runs."""
+        file_signatures = {}
+        symlinks = set()
+        for root, directories, files in os.walk(self.workflow_workspace):
+            directories[:] = self._exclude_internal_workflow_paths(
+                root, directories, self.workflow_workspace
+            )
+            files = self._exclude_internal_workflow_paths(
+                root, files, self.workflow_workspace
+            )
+            regular_directories = []
+            for directory in directories:
+                if self._is_file_transfer_directory(directory):
+                    continue
+                path = os.path.join(root, directory)
+                relative_path = os.path.relpath(path, self.workflow_workspace)
+                if os.path.islink(path):
+                    symlinks.add(relative_path)
+                else:
+                    regular_directories.append(directory)
+            directories[:] = regular_directories
+
+            for filename in files:
+                path = os.path.join(root, filename)
+                relative_path = os.path.relpath(path, self.workflow_workspace)
+                if os.path.islink(path):
+                    symlinks.add(relative_path)
+                    continue
+                try:
+                    file_signatures[relative_path] = self._file_signature(path)
+                except FileNotFoundError:
+                    # A concurrently removed file cannot be an input to this job.
+                    continue
+        return file_signatures, symlinks
+
+    def _prepare_file_transfer(self):
+        """Prepare an empty local destination for the returned sandbox."""
+        input_files = self._get_input_files().split(",")
+        input_files = [filename for filename in input_files if filename]
+        self.input_file_signatures, self.input_symlinks = self._snapshot_workspace()
+        os.makedirs(self.file_transfer_workspace)
+        return ",".join(
+            os.path.join(self.workflow_workspace, filename) for filename in input_files
+        )
+
+    def cleanup_file_transfer(self):
+        """Remove the local HTCondor file-transfer workspace."""
+        try:
+            shutil.rmtree(self.file_transfer_workspace)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logging.error(
+                "Failed to remove HTCondor file-transfer directory %s",
+                self.file_transfer_workspace,
+                exc_info=True,
+            )
+
+    def _validate_promotion_path(self, path):
+        """Ensure that an output destination remains inside the workspace."""
+        workspace = os.path.realpath(self.workflow_workspace)
+        parent = os.path.realpath(os.path.dirname(path))
+        if os.path.commonpath([workspace, parent]) != workspace:
+            raise RuntimeError(
+                "HTCondor output path escapes the workflow workspace: {}".format(path)
+            )
+
+    def _was_input_symlink(self, relative_path):
+        """Return whether a path is or descends from an input symlink."""
+        path_parts = relative_path.split(os.sep)
+        return any(
+            os.path.join(*path_parts[:part_count]) in self.input_symlinks
+            for part_count in range(1, len(path_parts) + 1)
+        )
+
+    @staticmethod
+    def _raise_concurrent_modification(relative_path):
+        """Raise an output conflict for a locally changed workspace path."""
+        raise RuntimeError(
+            "HTCondor output conflicts with a concurrently modified "
+            "workspace file: {}".format(relative_path)
+        )
+
+    def promote_output(self):
+        """Move new and modified HTCondor output files into the workspace."""
+        if not os.path.isdir(self.file_transfer_workspace):
+            raise RuntimeError(
+                "HTCondor file-transfer directory does not exist: {}".format(
+                    self.file_transfer_workspace
+                )
+            )
+
+        for root, directories, files in os.walk(self.file_transfer_workspace):
+            directories[:] = self._exclude_internal_workflow_paths(
+                root, directories, self.file_transfer_workspace
+            )
+            files = self._exclude_internal_workflow_paths(
+                root, files, self.file_transfer_workspace
+            )
+            for directory in list(directories):
+                source = os.path.join(root, directory)
+                relative_path = os.path.relpath(source, self.file_transfer_workspace)
+                if self._was_input_symlink(relative_path):
+                    directories.remove(directory)
+                    continue
+                if os.path.islink(source):
+                    raise RuntimeError(
+                        "Refusing to promote HTCondor output symlink: {}".format(source)
+                    )
+
+                destination = os.path.join(self.workflow_workspace, relative_path)
+                self._validate_promotion_path(destination)
+                if os.path.islink(destination):
+                    self._raise_concurrent_modification(relative_path)
+                os.makedirs(destination, exist_ok=True)
+
+            for filename in files:
+                source = os.path.join(root, filename)
+                if os.path.islink(source):
+                    raise RuntimeError(
+                        "Refusing to promote HTCondor output symlink: {}".format(source)
+                    )
+
+                relative_path = os.path.relpath(source, self.file_transfer_workspace)
+                if relative_path in self.INTERNAL_OUTPUT_FILES:
+                    continue
+                if self._was_input_symlink(relative_path):
+                    continue
+
+                destination = os.path.join(self.workflow_workspace, relative_path)
+                self._validate_promotion_path(destination)
+                input_signature = self.input_file_signatures.get(relative_path)
+                destination_exists = os.path.lexists(destination)
+
+                if input_signature is not None:
+                    if not destination_exists or os.path.islink(destination):
+                        self._raise_concurrent_modification(relative_path)
+                    if self._file_signature(destination) != input_signature:
+                        if os.path.isfile(destination) and self._files_equal(
+                            source, destination
+                        ):
+                            continue
+                        self._raise_concurrent_modification(relative_path)
+                    if self._files_equal(source, destination):
+                        continue
+                elif destination_exists:
+                    if (
+                        not os.path.islink(destination)
+                        and os.path.isfile(destination)
+                        and self._files_equal(source, destination)
+                    ):
+                        continue
+                    self._raise_concurrent_modification(relative_path)
+
+                os.makedirs(os.path.dirname(destination), exist_ok=True)
+                os.replace(source, destination)
+
+        self.cleanup_file_transfer()
+
     def _get_input_files(self):
         """Get files and dirs from workflow space."""
         input_files = []
@@ -284,7 +525,12 @@ class HTCondorJobManagerCERN(JobManager):
         forbidden_files = [".job.ad", ".machine.ad", ".chirp.config"]
         skip_extensions = (".err", ".log", ".out")
         for item in os.listdir(self.workflow_workspace):
-            if item not in forbidden_files and not item.endswith(skip_extensions):
+            if (
+                item not in forbidden_files
+                and not item.endswith(skip_extensions)
+                and not self._is_file_transfer_directory(item)
+                and not self._is_internal_workflow_path(item)
+            ):
                 input_files.append(item)
 
         return ",".join(input_files)

--- a/reana_job_controller/htcondorcern_job_manager.py
+++ b/reana_job_controller/htcondorcern_job_manager.py
@@ -43,7 +43,10 @@ class HTCondorJobManagerCERN(JobManager):
         "_condor_stdout",
         "condor_exec.exe",
     }
-    INTERNAL_WORKFLOW_PATHS = {"yadage": {"_yadage"}}
+    INTERNAL_WORKFLOW_PATHS = {
+        "snakemake": {".snakemake"},
+        "yadage": {"_yadage"},
+    }
 
     MAX_NUM_RETRIES = 3
     """Maximum number of tries used for getting schedd, job submission and
@@ -434,6 +437,18 @@ class HTCondorJobManagerCERN(JobManager):
             for part_count in range(1, len(path_parts) + 1)
         )
 
+    def _verify_unchanged_input_symlink(self, relative_path, returned_path):
+        """Reject changed content returned for an input file symlink."""
+        destination = os.path.join(self.workflow_workspace, relative_path)
+        if not os.path.islink(destination) or not os.path.isfile(destination):
+            self._raise_concurrent_modification(relative_path)
+        try:
+            files_equal = self._files_equal(returned_path, destination)
+        except OSError:
+            files_equal = False
+        if not files_equal:
+            self._raise_concurrent_modification(relative_path)
+
     @staticmethod
     def _raise_concurrent_modification(relative_path):
         """Raise an output conflict for a locally changed workspace path."""
@@ -462,6 +477,11 @@ class HTCondorJobManagerCERN(JobManager):
                 source = os.path.join(root, directory)
                 relative_path = os.path.relpath(source, self.file_transfer_workspace)
                 if self._was_input_symlink(relative_path):
+                    logging.warning(
+                        "Skipping returned HTCondor content rooted at input "
+                        "directory symlink: %s",
+                        relative_path,
+                    )
                     directories.remove(directory)
                     continue
                 if os.path.islink(source):
@@ -486,6 +506,7 @@ class HTCondorJobManagerCERN(JobManager):
                 if relative_path in self.INTERNAL_OUTPUT_FILES:
                     continue
                 if self._was_input_symlink(relative_path):
+                    self._verify_unchanged_input_symlink(relative_path, source)
                     continue
 
                 destination = os.path.join(self.workflow_workspace, relative_path)

--- a/reana_job_controller/job_manager.py
+++ b/reana_job_controller/job_manager.py
@@ -9,6 +9,7 @@
 """Job Manager."""
 
 import json
+import uuid
 
 from reana_commons.utils import calculate_file_access_time
 from reana_db.database import Session
@@ -54,6 +55,7 @@ class JobManager:
         self.workflow_workspace = workflow_workspace
         self.job_name = job_name
         self.env_vars = self._extend_env_vars(env_vars or {})
+        self.job_id = str(uuid.uuid4())
 
     def execution_hook(fn):
         """Add before execution hooks and DB operations."""
@@ -111,6 +113,7 @@ class JobManager:
     def create_job_in_db(self, backend_job_id):
         """Create job in db."""
         job_db_entry = JobTable(
+            id_=self.job_id,
             backend_job_id=backend_job_id,
             workflow_uuid=self.workflow_uuid,
             status=JobStatus.created,
@@ -126,7 +129,6 @@ class JobManager:
         )
         Session.add(job_db_entry)
         Session.commit()
-        self.job_id = str(job_db_entry.id_)
 
     def cache_job(self):
         """Cache a job."""

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -323,6 +323,57 @@ class JobMonitorHTCondorCERN(JobMonitor):
             query += base_query.format(job_id)
         return query[:-2]
 
+    def _finalise_completed_job(self, job_id, job_dict, condor_job, app):
+        """Retrieve a completed HTCondor job and publish its final status."""
+        backend_job_id = job_dict["backend_job_id"]
+        job_manager = job_dict["obj"]
+        exit_code = condor_job.get("ExitCode", condor_job.get("ExitStatus"))
+        final_status = "finished" if exit_code == 0 else "failed"
+
+        if final_status == "failed":
+            logging.info(
+                "Job job_id: {0}, condor_job_id: {1} failed".format(
+                    job_id, backend_job_id
+                )
+            )
+
+        try:
+            app.htcondor_executor.submit(
+                self.job_manager_cls.spool_output,
+                backend_job_id,
+            ).result()
+        except Exception as error:
+            final_status = "failed"
+            logs = (
+                "Failed to retrieve output for REANA job {0} from HTCondor "
+                "job {1}: {2}".format(job_id, backend_job_id, error)
+            )
+            logging.error(logs, exc_info=True)
+            job_manager.stop(backend_job_id)
+            job_manager.cleanup_file_transfer()
+        else:
+            try:
+                job_manager.promote_output()
+            except Exception as error:
+                final_status = "failed"
+                logs = (
+                    "Failed to promote output for REANA job {0} from HTCondor "
+                    "job {1}: {2}".format(job_id, backend_job_id, error)
+                )
+                logging.error(logs, exc_info=True)
+                job_manager.cleanup_file_transfer()
+            else:
+                job_logs = app.htcondor_executor.submit(
+                    self.job_manager_cls.get_logs,
+                    backend_job_id,
+                    workspace=job_manager.workflow_workspace,
+                )
+                logs = job_logs.result()
+
+        store_job_logs(job_id, logs)
+        update_job_status(job_id, final_status)
+        job_dict["deleted"] = True
+
     def watch_jobs(self, job_db, app):
         """Watch currently running HTCondor jobs.
 
@@ -371,38 +422,24 @@ class JobMonitorHTCondorCERN(JobMonitor):
                             logging.error(msg)
                             update_job_status(job_id, "failed")
                             store_job_logs(job_id, msg)
+                            job_dict["obj"].cleanup_file_transfer()
+                            job_dict["deleted"] = True
                         continue
                     if condor_job["JobStatus"] == condorJobStatus["Completed"]:
-                        exit_code = condor_job.get(
-                            "ExitCode", condor_job.get("ExitStatus")
-                        )
-                        if exit_code == 0:
-                            update_job_status(job_id, "finished")
-                        else:
-                            logging.info(
-                                "Job job_id: {0}, condor_job_id: {1} "
-                                "failed".format(job_id, condor_job["ClusterId"])
-                            )
-                            update_job_status(job_id, "failed")
-                        app.htcondor_executor.submit(
-                            self.job_manager_cls.spool_output,
-                            job_dict["backend_job_id"],
-                        ).result()
-                        job_logs = app.htcondor_executor.submit(
-                            self.job_manager_cls.get_logs,
-                            job_dict["backend_job_id"],
-                            workspace=job_db[job_id]["obj"].workflow_workspace,
-                        )
-                        logs = job_logs.result()
-                        store_job_logs(job_id, logs)
-
-                        job_db[job_id]["deleted"] = True
+                        self._finalise_completed_job(job_id, job_dict, condor_job, app)
                     elif (
                         condor_job["JobStatus"] == condorJobStatus["Held"]
                         and int(condor_job["HoldReasonCode"]) not in ignore_hold_codes
                     ):
-                        logging.info("Job was held, will delete and set as failed")
+                        msg = ("HTCondor job {} was held with reason code {}.").format(
+                            condor_job["ClusterId"],
+                            condor_job["HoldReasonCode"],
+                        )
+                        logging.info("%s It will be removed.", msg)
                         self.job_manager_cls.stop(condor_job["ClusterId"])
+                        store_job_logs(job_id, msg)
+                        update_job_status(job_id, "failed")
+                        job_dict["obj"].cleanup_file_transfer()
                         job_db[job_id]["deleted"] = True
                 time.sleep(120)
             except Exception as e:

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -671,5 +671,5 @@ def query_condor_jobs(app, backend_job_ids):
     htcondorcern_job_manager_cls = COMPUTE_BACKENDS["htcondorcern"]()
     schedd = htcondorcern_job_manager_cls._get_schedd()
     logging.info("Querying jobs {}".format(backend_job_ids))
-    condor_jobs = schedd.xquery(requirements=query, projection=ads)
+    condor_jobs = schedd.query(constraint=query, projection=ads)
     return condor_jobs

--- a/reana_job_controller/job_monitor.py
+++ b/reana_job_controller/job_monitor.py
@@ -329,6 +329,7 @@ class JobMonitorHTCondorCERN(JobMonitor):
         job_manager = job_dict["obj"]
         exit_code = condor_job.get("ExitCode", condor_job.get("ExitStatus"))
         final_status = "finished" if exit_code == 0 else "failed"
+        logs = ""
 
         if final_status == "failed":
             logging.info(
@@ -353,22 +354,30 @@ class JobMonitorHTCondorCERN(JobMonitor):
             job_manager.cleanup_file_transfer()
         else:
             try:
-                job_manager.promote_output()
-            except Exception as error:
-                final_status = "failed"
-                logs = (
-                    "Failed to promote output for REANA job {0} from HTCondor "
-                    "job {1}: {2}".format(job_id, backend_job_id, error)
-                )
-                logging.error(logs, exc_info=True)
-                job_manager.cleanup_file_transfer()
-            else:
                 job_logs = app.htcondor_executor.submit(
                     self.job_manager_cls.get_logs,
                     backend_job_id,
-                    workspace=job_manager.workflow_workspace,
+                    workspace=job_manager.file_transfer_workspace,
                 )
                 logs = job_logs.result()
+            except Exception as error:
+                final_status = "failed"
+                logs = (
+                    "Failed to capture output logs for REANA job {0} from "
+                    "HTCondor job {1}: {2}".format(job_id, backend_job_id, error)
+                )
+                logging.error(logs, exc_info=True)
+            try:
+                job_manager.promote_output()
+            except Exception as error:
+                final_status = "failed"
+                promotion_error = (
+                    "Failed to promote output for REANA job {0} from HTCondor "
+                    "job {1}: {2}".format(job_id, backend_job_id, error)
+                )
+                logs = "{0}\n{1}".format(logs, promotion_error)
+                logging.error(promotion_error, exc_info=True)
+                job_manager.cleanup_file_transfer()
 
         store_job_logs(job_id, logs)
         update_job_status(job_id, final_status)

--- a/reana_job_controller/rest.py
+++ b/reana_job_controller/rest.py
@@ -53,6 +53,13 @@ _SECRETS_CACHE = None
 """Cache for user secrets."""
 
 
+def _cleanup_file_transfer(job_id):
+    """Clean backend-specific local file-transfer state for a job."""
+    cleanup = getattr(JOB_DB[job_id]["obj"], "cleanup_file_transfer", None)
+    if cleanup:
+        cleanup()
+
+
 def get_cached_user_secrets() -> UserSecrets:
     """Return cached user secrets."""
     global _SECRETS_CACHE
@@ -506,6 +513,7 @@ def delete_job(job_id):  # noqa
             backend_job_id = retrieve_backend_job_id(job_id)
             job_manager_cls = current_app.config["COMPUTE_BACKENDS"][compute_backend]()
             job_manager_cls.stop(backend_job_id)
+            _cleanup_file_transfer(job_id)
             return jsonify(), 204
         except ComputingBackendSubmissionError as e:
             return (
@@ -586,6 +594,7 @@ def shutdown():
                 logs = job_manager_cls.get_logs(backend_job_id, workspace=workspace)
                 store_job_logs(job_id, logs)
                 job_manager_cls.stop(backend_job_id)
+                _cleanup_file_transfer(job_id)
                 update_job_status(job_id, JobStatus.stopped.name)
                 # FIXME: ideally also here we would not access the database directly
                 JOB_DB[job_id]["deleted"] = True

--- a/reana_job_controller/schemas.py
+++ b/reana_job_controller/schemas.py
@@ -21,16 +21,16 @@ from reana_job_controller.config import (
 )
 
 try:
-    import classad as _classad
+    import classad2 as _classad
 except ImportError:
-    # `classad` ships with the `htcondor` extras. In a correctly-built
+    # `classad2` ships with the `htcondor` extras. In a correctly-built
     # job-controller image this import must succeed. We do not fail at
     # module load time so that test environments and non-HTCondor builds
     # can still import this module, but we log a warning so misbuilt
     # production images leave an obvious breadcrumb.
     _classad = None
     logging.getLogger(__name__).warning(
-        "classad library is not available; htcondor_requirements "
+        "classad2 library is not available; htcondor_requirements "
         "expressions will not be validated at the schema layer. Expected "
         "only in test environments and non-HTCondor builds."
     )
@@ -131,10 +131,10 @@ def _validate_htcondor_quantity_string(field_name, default_unit):
 def _validate_classad_expression(value):
     """Validate that the value can be parsed as an HTCondor ClassAd expression.
 
-    No-op when the ``classad`` library is not importable. The
+    No-op when the ``classad2`` library is not importable. The
     module-load-time warning above flags this state in production logs.
-    The HTCondor manager submission path imports ``classad`` at module
-    level, so a job-controller environment that lacks ``classad`` cannot
+    The HTCondor manager submission path imports ``classad2`` at module
+    level, so a job-controller environment that lacks ``classad2`` cannot
     submit HTCondor jobs at all, regardless of whether schema validation
     runs.
     """
@@ -144,7 +144,7 @@ def _validate_classad_expression(value):
         return
     try:
         _classad.ExprTree(value)
-    except (SyntaxError, RuntimeError, ValueError) as exc:
+    except (_classad.ClassAdException, SyntaxError, RuntimeError, ValueError) as exc:
         raise ValidationError(
             f"htcondor_requirements is not a valid ClassAd expression: {exc}"
         )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "htcondor": [
-        "htcondor>=9.0.17",
+        "htcondor>=24.12,<25",
     ],
     "tests": [
         "reana-commons[kubernetes,tests]>=0.95.0a20,<0.96.0",

--- a/tests/test_htcondorcern_job_manager.py
+++ b/tests/test_htcondorcern_job_manager.py
@@ -12,10 +12,11 @@ from unittest import mock
 
 import pytest
 
-classad = pytest.importorskip("classad")
-pytest.importorskip("htcondor")
+classad = pytest.importorskip("classad2")
+htcondor = pytest.importorskip("htcondor2")
 
 from reana_job_controller import htcondorcern_job_manager  # noqa: E402
+from reana_job_controller import job_monitor  # noqa: E402
 
 
 @pytest.fixture
@@ -32,17 +33,31 @@ def manager_dependencies():
 
 
 @pytest.fixture
-def captured_job_ad(manager_dependencies):
-    """Patch ``execute()``'s side-effecting helpers and capture the job_ad.
+def manager(manager_dependencies):
+    """Construct an HTCondor manager with its external dependencies patched."""
+    return htcondorcern_job_manager.HTCondorJobManagerCERN(
+        docker_img="img",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid="uuid",
+        workflow_workspace="/data",
+        job_name="job",
+        htcondor_max_runtime="3600",
+    )
+
+
+@pytest.fixture
+def captured_submit(manager_dependencies):
+    """Patch ``execute()``'s side effects and capture the submit description.
 
     Returns a builder ``submit(**kwargs)`` that constructs the manager
     with the given kwargs, calls ``execute()``, and returns the
-    ``classad.ClassAd`` that the manager would have sent to the schedd.
+    ``htcondor2.Submit`` object that the manager would send to the schedd.
     """
     captured = {}
 
-    def fake_executor_submit(_fn, job_ad):
-        captured["job_ad"] = job_ad
+    def fake_executor_submit(_fn, submit):
+        captured["submit"] = submit
         future = mock.MagicMock()
         future.result.return_value = "cluster123"
         return future
@@ -55,8 +70,6 @@ def captured_job_ad(manager_dependencies):
         htcondorcern_job_manager, "current_app", fake_app
     ), mock.patch.object(htcondorcern_job_manager.os, "chdir"), mock.patch.object(
         Manager, "_format_arguments", return_value="echo|base64 -d"
-    ), mock.patch.object(
-        Manager, "_format_env_vars", return_value=""
     ), mock.patch.object(
         Manager, "_get_input_files", return_value=""
     ), mock.patch.object(
@@ -79,7 +92,7 @@ def captured_job_ad(manager_dependencies):
             base.update(kwargs)
             manager = Manager(**base)
             manager.execute()
-            return captured["job_ad"]
+            return captured["submit"]
 
         yield build_and_execute
 
@@ -125,46 +138,238 @@ def test_constructor_defaults_htcondor_request_attributes_to_empty(
     assert manager.htcondor_requirements == ""
 
 
-# --- job_ad mapping in execute() ----------------------------------------------
+# --- submit-description mapping in execute() ----------------------------------
 
 
-def test_execute_sets_request_cpus_as_int(captured_job_ad):
-    job_ad = captured_job_ad(htcondor_request_cpus="4")
-    assert int(job_ad["RequestCpus"]) == 4
+def test_execute_builds_v2_submit_description(captured_submit):
+    """The manager must use the v2 Submit API with string values."""
+    submit = captured_submit()
+
+    assert isinstance(submit, htcondor.Submit)
+    assert submit["description"] == "wf_job"
+    assert submit["executable"] == "./job_wrapper.sh"
+    assert submit["MY.JobMaxRetries"] == "3"
+    assert submit["MY.DockerImage"] == classad.quote("img")
+    assert submit["MY.WantDocker"] == "True"
+    assert submit["MY.DockerNetworkType"] == classad.quote("host")
+    assert submit["MY.MaxRunTime"] == "3600"
+    assert submit["MY.Requirements"] == "True"
+    assert "log" not in submit.keys()
+    assert all(isinstance(value, str) for value in submit.values())
 
 
-def test_execute_converts_request_memory_to_mib(captured_job_ad):
-    job_ad = captured_job_ad(htcondor_request_memory="4 GB")
-    assert int(job_ad["RequestMemory"]) == 4096
+def test_execute_preserves_unpacked_image_submission(captured_submit):
+    """Unpacked images must keep using the generated Singularity wrapper."""
+    submit = captured_submit(unpacked_img=True)
+
+    assert submit["executable"] == "./job_singularity_wrapper.sh"
+    assert "arguments" not in submit.keys()
+    assert "MY.DockerImage" not in submit.keys()
+    assert "MY.WantDocker" not in submit.keys()
 
 
-def test_execute_rounds_up_request_memory(captured_job_ad):
+def test_execute_sets_request_cpus_as_string(captured_submit):
+    submit = captured_submit(htcondor_request_cpus="4")
+    assert submit["request_cpus"] == "4"
+
+
+def test_execute_converts_request_memory_to_mib(captured_submit):
+    submit = captured_submit(htcondor_request_memory="4 GB")
+    assert submit["request_memory"] == "4096"
+
+
+def test_execute_rounds_up_request_memory(captured_submit):
     """A ``1 KB`` request must not silently become ``0`` MiB."""
-    job_ad = captured_job_ad(htcondor_request_memory="1 KB")
-    assert int(job_ad["RequestMemory"]) == 1
+    submit = captured_submit(htcondor_request_memory="1 KB")
+    assert submit["request_memory"] == "1"
 
 
-def test_execute_converts_request_disk_to_kib(captured_job_ad):
-    job_ad = captured_job_ad(htcondor_request_disk="10 GB")
-    assert int(job_ad["RequestDisk"]) == 10485760
+def test_execute_converts_request_disk_to_kib(captured_submit):
+    submit = captured_submit(htcondor_request_disk="10 GB")
+    assert submit["request_disk"] == "10485760"
 
 
-def test_execute_sets_requirements_as_classad_exprtree(captured_job_ad):
-    job_ad = captured_job_ad(htcondor_requirements='(Arch =?= "aarch64")')
-    expr = job_ad["Requirements"]
+def test_execute_sets_requirements_as_complete_classad_expression(captured_submit):
+    submit = captured_submit(htcondor_requirements='(Arch =?= "aarch64")')
+    rendered = submit["MY.Requirements"]
+    expr = classad.ExprTree(rendered)
+
     assert isinstance(expr, classad.ExprTree)
-    rendered = str(expr)
     # Asserting on stable fragments rather than exact normal form, since
-    # classad's str() can vary in spacing/case across library versions.
+    # classad2's str() can vary in spacing/case across library versions.
     assert "Arch" in rendered
     assert "=?=" in rendered
     assert "aarch64" in rendered
 
 
-def test_execute_omits_request_attrs_when_absent(captured_job_ad):
-    """Absent fields must not appear in the produced ClassAd."""
-    job_ad = captured_job_ad()
-    assert "RequestCpus" not in job_ad
-    assert "RequestMemory" not in job_ad
-    assert "RequestDisk" not in job_ad
-    assert "Requirements" not in job_ad
+def test_execute_formats_multiple_environment_variables(captured_submit):
+    """Environment variables must use HTCondor's portable new syntax."""
+    submit = captured_submit(env_vars={"CACHE": "on", "LABEL": "two words"})
+    environment = submit["environment"]
+
+    assert environment.startswith("\"'CACHE=on' 'LABEL=two words' ")
+    assert "'REANA_WORKSPACE=/data'" in environment
+    assert "'REANA_WORKFLOW_UUID=uuid'" in environment
+    assert environment.endswith('"')
+
+
+def test_format_env_vars_escapes_quotes(manager):
+    """Environment syntax must preserve literal single and double quotes."""
+    manager.env_vars = {"QUOTED": "a'b\"c"}
+
+    assert manager._format_env_vars() == "\"'QUOTED=a''b\"\"c'\""
+
+
+@pytest.mark.parametrize("forbidden_character", ["\n", "\r", "\x00"])
+def test_execute_rejects_submit_command_injection(captured_submit, forbidden_character):
+    """Untrusted values must not create additional submit-file lines."""
+    job_name = "job{}MY.MaxRunTime = 999999".format(forbidden_character)
+
+    with pytest.raises(ValueError, match="description"):
+        captured_submit(job_name=job_name)
+
+
+def test_execute_rejects_environment_command_injection(captured_submit):
+    """Environment values must not inject additional submit-file lines."""
+    env_vars = {"CACHE": "on\nMY.MaxRunTime = 999999"}
+
+    with pytest.raises(ValueError, match="environment"):
+        captured_submit(env_vars=env_vars)
+
+
+def test_execute_omits_optional_request_attrs_when_absent(captured_submit):
+    """Absent resource requests must not appear in the submit description."""
+    submit = captured_submit()
+    keys = submit.keys()
+
+    assert "request_cpus" not in keys
+    assert "request_memory" not in keys
+    assert "request_disk" not in keys
+    assert submit["MY.Requirements"] == "True"
+
+
+# --- schedd interactions ------------------------------------------------------
+
+
+def test_get_schedd_locates_configured_remote_schedd():
+    """The v2 API must receive the remote schedd advertisement explicitly."""
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+    schedd_host = "bigbird23.cern.ch"
+    schedd_location = mock.sentinel.schedd_location
+    schedd = mock.sentinel.schedd
+    collector = mock.MagicMock()
+    collector.locate.return_value = schedd_location
+    mock_htcondor = mock.MagicMock()
+    mock_htcondor.param = {"SCHEDD_HOST": schedd_host}
+    mock_htcondor.Collector.return_value = collector
+    mock_htcondor.Schedd.return_value = schedd
+
+    with mock.patch.object(
+        htcondorcern_job_manager, "htcondor", mock_htcondor
+    ), mock.patch.object(
+        htcondorcern_job_manager.thread_local,
+        "MONITOR_THREAD_SCHEDD",
+        None,
+        create=True,
+    ):
+        assert Manager._get_schedd() is schedd
+        assert Manager._get_schedd() is schedd
+
+    collector.locate.assert_called_once_with(
+        mock_htcondor.DaemonType.Schedd, schedd_host
+    )
+    mock_htcondor.Schedd.assert_called_once_with(schedd_location)
+
+
+def test_get_schedd_does_not_fall_back_to_local_daemon():
+    """A missing remote advertisement must not trigger local daemon lookup."""
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+    collector = mock.MagicMock()
+    collector.locate.return_value = None
+    mock_htcondor = mock.MagicMock()
+    mock_htcondor.param = {"SCHEDD_HOST": "missing.cern.ch"}
+    mock_htcondor.Collector.return_value = collector
+
+    with mock.patch.object(
+        htcondorcern_job_manager, "htcondor", mock_htcondor
+    ), mock.patch.object(
+        htcondorcern_job_manager.thread_local,
+        "MONITOR_THREAD_SCHEDD",
+        None,
+        create=True,
+    ), pytest.raises(
+        RuntimeError, match="missing.cern.ch"
+    ):
+        Manager._get_schedd.__wrapped__()
+
+    mock_htcondor.Schedd.assert_not_called()
+
+
+def test_submit_spools_submit_result_and_returns_cluster(manager):
+    """A spooled v2 submission returns the cluster from SubmitResult."""
+    submit = htcondor.Submit({"executable": "/bin/true"})
+    result = mock.MagicMock()
+    result.cluster.return_value = 123
+    schedd = mock.MagicMock()
+    schedd.submit.return_value = result
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+
+    with mock.patch.object(
+        Manager, "_get_schedd", return_value=schedd
+    ), mock.patch.object(Manager, "_spool_input") as spool_input:
+        assert manager._submit(submit) == 123
+
+    schedd.submit.assert_called_once_with(submit, count=1, spool=True)
+    spool_input.assert_called_once_with(result)
+
+
+def test_spool_input_passes_submit_result_to_schedd():
+    """The v2 spool API must receive the original SubmitResult."""
+    result = mock.sentinel.submit_result
+    schedd = mock.MagicMock()
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+
+    with mock.patch.object(Manager, "_get_schedd", return_value=schedd):
+        Manager._spool_input(result)
+
+    schedd.spool.assert_called_once_with(result)
+
+
+@pytest.mark.parametrize(
+    "history, expected", [([], None), ([{"ClusterId": 123}], {"ClusterId": 123})]
+)
+def test_find_job_in_history_handles_v2_list_result(history, expected):
+    """The v2 history API returns a list rather than an iterator."""
+    schedd = mock.MagicMock()
+    schedd.history.return_value = history
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+
+    with mock.patch.object(Manager, "_get_schedd", return_value=schedd):
+        assert Manager.find_job_in_history(123) == expected
+
+
+def test_query_condor_jobs_uses_v2_query():
+    """Job monitoring must use query(), because v2 removed xquery()."""
+    expected_jobs = [{"ClusterId": 1}]
+    schedd = mock.MagicMock()
+    schedd.query.return_value = expected_jobs
+    manager = mock.MagicMock()
+    manager._get_schedd.return_value = schedd
+    manager_factory = mock.MagicMock(return_value=manager)
+    backend_job_ids = [1, 2]
+
+    with mock.patch.dict(
+        job_monitor.COMPUTE_BACKENDS, {"htcondorcern": manager_factory}
+    ):
+        assert job_monitor.query_condor_jobs(None, backend_job_ids) == expected_jobs
+
+    schedd.query.assert_called_once_with(
+        constraint=job_monitor.format_condor_job_que_query(backend_job_ids),
+        projection=[
+            "ClusterId",
+            "JobStatus",
+            "ExitCode",
+            "ExitStatus",
+            "HoldReasonCode",
+        ],
+    )

--- a/tests/test_htcondorcern_job_manager.py
+++ b/tests/test_htcondorcern_job_manager.py
@@ -8,6 +8,7 @@
 
 """Tests for the CERN HTCondor job manager."""
 
+import logging
 import os
 from unittest import mock
 
@@ -344,6 +345,29 @@ def test_prepare_file_transfer_excludes_yadage_engine_state(workspace_manager):
     )
 
 
+def test_prepare_file_transfer_excludes_snakemake_engine_state(workspace_manager):
+    """Do not transfer or snapshot Snakemake's concurrently updated state."""
+    workspace_manager.workflow.type_ = "snakemake"
+    workspace = workspace_manager.workflow_workspace
+    code_directory = os.path.join(workspace, "code")
+    os.makedirs(code_directory)
+    with open(os.path.join(code_directory, "analysis.py"), "w") as analysis:
+        analysis.write("print('hello')")
+    snakemake_state = os.path.join(workspace, ".snakemake", "metadata")
+    os.makedirs(snakemake_state)
+    with open(os.path.join(snakemake_state, "result"), "w") as metadata:
+        metadata.write("engine state")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        input_files = workspace_manager._prepare_file_transfer().split(",")
+
+    assert input_files == [code_directory]
+    assert not any(
+        path == ".snakemake" or path.startswith(".snakemake/")
+        for path in workspace_manager.input_file_signatures
+    )
+
+
 def test_promote_output_ignores_returned_yadage_engine_state(workspace_manager):
     """Do not overwrite Yadage state defensively if HTCondor returns it."""
     workspace_manager.workflow.type_ = "yadage"
@@ -372,6 +396,41 @@ def test_promote_output_ignores_returned_yadage_engine_state(workspace_manager):
 
     with open(snapshot_path) as snapshot:
         assert snapshot.read() == "current engine state"
+    with open(os.path.join(workspace, "result.txt")) as result:
+        assert result.read() == "result"
+    assert not os.path.exists(workspace_manager.file_transfer_workspace)
+
+
+def test_promote_output_ignores_returned_snakemake_engine_state(workspace_manager):
+    """Do not overwrite concurrently updated Snakemake state."""
+    workspace_manager.workflow.type_ = "snakemake"
+    workspace = workspace_manager.workflow_workspace
+    snakemake_state = os.path.join(workspace, ".snakemake", "metadata")
+    os.makedirs(snakemake_state)
+    metadata_path = os.path.join(snakemake_state, "result")
+    with open(metadata_path, "w") as metadata:
+        metadata.write("initial engine state")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    with open(metadata_path, "w") as metadata:
+        metadata.write("current engine state")
+    returned_snakemake_state = os.path.join(
+        workspace_manager.file_transfer_workspace, ".snakemake", "metadata"
+    )
+    os.makedirs(returned_snakemake_state)
+    with open(os.path.join(returned_snakemake_state, "result"), "w") as metadata:
+        metadata.write("stale engine state")
+    with open(
+        os.path.join(workspace_manager.file_transfer_workspace, "result.txt"), "w"
+    ) as result:
+        result.write("result")
+
+    workspace_manager.promote_output()
+
+    with open(metadata_path) as metadata:
+        assert metadata.read() == "current engine state"
     with open(os.path.join(workspace, "result.txt")) as result:
         assert result.read() == "result"
     assert not os.path.exists(workspace_manager.file_transfer_workspace)
@@ -475,7 +534,7 @@ def test_promote_output_preserves_input_symlink(workspace_manager):
         os.path.join(workspace_manager.file_transfer_workspace, "input-link"),
         "w",
     ) as returned_file:
-        returned_file.write("modified by job")
+        returned_file.write("input")
 
     workspace_manager.promote_output()
 
@@ -483,6 +542,97 @@ def test_promote_output_preserves_input_symlink(workspace_manager):
     assert os.readlink(input_link) == "target.txt"
     with open(target) as target_file:
         assert target_file.read() == "input"
+
+
+def test_promote_output_rejects_same_size_modified_input_symlink(workspace_manager):
+    """Content-check same-size modifications through an input symlink."""
+    workspace = workspace_manager.workflow_workspace
+    target = os.path.join(workspace, "target.txt")
+    input_link = os.path.join(workspace, "input-link")
+    with open(target, "w") as target_file:
+        target_file.write("input")
+    os.symlink("target.txt", input_link)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    returned_path = os.path.join(
+        workspace_manager.file_transfer_workspace, "input-link"
+    )
+    with open(returned_path, "w") as returned_file:
+        returned_file.write("other")
+
+    assert os.path.getsize(returned_path) == os.path.getsize(target)
+    with pytest.raises(RuntimeError, match="concurrently modified"):
+        workspace_manager.promote_output()
+
+    assert os.path.islink(input_link)
+    with open(target) as target_file:
+        assert target_file.read() == "input"
+    assert os.path.isdir(workspace_manager.file_transfer_workspace)
+
+
+def test_promote_output_rejects_input_symlink_with_missing_target(
+    workspace_manager,
+):
+    """Fail clearly when an input symlink target disappears."""
+    workspace = workspace_manager.workflow_workspace
+    target = os.path.join(workspace, "target.txt")
+    input_link = os.path.join(workspace, "input-link")
+    with open(target, "w") as target_file:
+        target_file.write("input")
+    os.symlink("target.txt", input_link)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    os.unlink(target)
+    with open(
+        os.path.join(workspace_manager.file_transfer_workspace, "input-link"),
+        "w",
+    ) as returned_file:
+        returned_file.write("input")
+
+    with pytest.raises(RuntimeError, match="concurrently modified"):
+        workspace_manager.promote_output()
+
+    assert os.path.islink(input_link)
+    assert os.path.isdir(workspace_manager.file_transfer_workspace)
+
+
+def test_promote_output_warns_when_skipping_input_directory_symlink(
+    workspace_manager, caplog
+):
+    """Warn when discarding returned content beneath a directory symlink."""
+    workspace = workspace_manager.workflow_workspace
+    target = os.path.join(workspace, "target")
+    input_link = os.path.join(workspace, "input-link")
+    os.makedirs(target)
+    with open(os.path.join(target, "input.txt"), "w") as input_file:
+        input_file.write("input")
+    os.symlink("target", input_link)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    returned_directory = os.path.join(
+        workspace_manager.file_transfer_workspace, "input-link"
+    )
+    os.makedirs(returned_directory)
+    with open(os.path.join(returned_directory, "input.txt"), "w") as input_file:
+        input_file.write("modified by job")
+
+    with caplog.at_level(logging.WARNING):
+        workspace_manager.promote_output()
+
+    assert (
+        "Skipping returned HTCondor content rooted at input directory symlink"
+        in caplog.text
+    )
+    assert os.path.islink(input_link)
+    with open(os.path.join(target, "input.txt")) as input_file:
+        assert input_file.read() == "input"
+    assert not os.path.exists(workspace_manager.file_transfer_workspace)
 
 
 def test_promote_output_rejects_concurrent_modification(workspace_manager):

--- a/tests/test_htcondorcern_job_manager.py
+++ b/tests/test_htcondorcern_job_manager.py
@@ -8,6 +8,7 @@
 
 """Tests for the CERN HTCondor job manager."""
 
+import os
 from unittest import mock
 
 import pytest
@@ -71,7 +72,7 @@ def captured_submit(manager_dependencies):
     ), mock.patch.object(htcondorcern_job_manager.os, "chdir"), mock.patch.object(
         Manager, "_format_arguments", return_value="echo|base64 -d"
     ), mock.patch.object(
-        Manager, "_get_input_files", return_value=""
+        Manager, "_prepare_file_transfer", return_value=""
     ), mock.patch.object(
         Manager, "before_execution"
     ), mock.patch.object(
@@ -147,7 +148,9 @@ def test_execute_builds_v2_submit_description(captured_submit):
 
     assert isinstance(submit, htcondor.Submit)
     assert submit["description"] == "wf_job"
-    assert submit["executable"] == "./job_wrapper.sh"
+    assert submit["executable"] == "/data/job_wrapper.sh"
+    assert submit["initialdir"].startswith("/data/reana_job.")
+    assert submit["initialdir"].endswith(".filetransfer")
     assert submit["MY.JobMaxRetries"] == "3"
     assert submit["MY.DockerImage"] == classad.quote("img")
     assert submit["MY.WantDocker"] == "True"
@@ -162,7 +165,7 @@ def test_execute_preserves_unpacked_image_submission(captured_submit):
     """Unpacked images must keep using the generated Singularity wrapper."""
     submit = captured_submit(unpacked_img=True)
 
-    assert submit["executable"] == "./job_singularity_wrapper.sh"
+    assert submit["executable"] == "/data/job_singularity_wrapper.sh"
     assert "arguments" not in submit.keys()
     assert "MY.DockerImage" not in submit.keys()
     assert "MY.WantDocker" not in submit.keys()
@@ -246,6 +249,298 @@ def test_execute_omits_optional_request_attrs_when_absent(captured_submit):
     assert "request_memory" not in keys
     assert "request_disk" not in keys
     assert submit["MY.Requirements"] == "True"
+
+
+# --- output staging ----------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_manager(manager_dependencies, tmp_path):
+    """Construct an HTCondor manager with a temporary workflow workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manager = htcondorcern_job_manager.HTCondorJobManagerCERN(
+        docker_img="img",
+        cmd="ls",
+        env_vars={},
+        workflow_uuid="uuid",
+        workflow_workspace=str(workspace),
+        job_name="job",
+    )
+    return manager
+
+
+def test_prepare_file_transfer_uses_job_uuid_workspace(workspace_manager):
+    """Stage returned files under the workflow workspace using the job UUID."""
+    workspace = workspace_manager.workflow_workspace
+    input_path = os.path.join(workspace, "input.txt")
+    with open(input_path, "w") as input_file:
+        input_file.write("input")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"), mock.patch.object(
+        workspace_manager, "_hash_file"
+    ) as hash_file:
+        input_files = workspace_manager._prepare_file_transfer()
+
+    assert input_files == input_path
+    assert workspace_manager.job_id in workspace_manager.file_transfer_workspace
+    assert os.path.isdir(workspace_manager.file_transfer_workspace)
+    assert workspace_manager.input_file_signatures["input.txt"]
+    hash_file.assert_not_called()
+
+
+def test_prepare_file_transfer_records_symlinks_without_following_them(
+    workspace_manager,
+):
+    """Do not inspect symlink targets when snapshotting the workspace."""
+    workspace = workspace_manager.workflow_workspace
+    dangling_link = os.path.join(workspace, "dangling-link")
+    os.symlink("missing-target", dangling_link)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"), mock.patch.object(
+        workspace_manager, "_hash_file"
+    ) as hash_file:
+        workspace_manager._prepare_file_transfer()
+
+    assert "dangling-link" in workspace_manager.input_symlinks
+    assert "dangling-link" not in workspace_manager.input_file_signatures
+    hash_file.assert_not_called()
+
+
+def test_get_input_files_excludes_file_transfer_directories(workspace_manager):
+    """Do not send another HTCondor job's staging directory as input."""
+    transfer_directory = os.path.join(
+        workspace_manager.workflow_workspace,
+        "reana_job.another-job.filetransfer",
+    )
+    os.makedirs(transfer_directory)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        input_files = workspace_manager._get_input_files().split(",")
+
+    assert "reana_job.another-job.filetransfer" not in input_files
+
+
+def test_prepare_file_transfer_excludes_yadage_engine_state(workspace_manager):
+    """Do not transfer or snapshot Yadage's concurrently updated state."""
+    workspace_manager.workflow.type_ = "yadage"
+    workspace = workspace_manager.workflow_workspace
+    code_directory = os.path.join(workspace, "code")
+    os.makedirs(code_directory)
+    with open(os.path.join(code_directory, "analysis.py"), "w") as analysis:
+        analysis.write("print('hello')")
+    yadage_state = os.path.join(workspace, "_yadage", "adage")
+    os.makedirs(yadage_state)
+    with open(os.path.join(yadage_state, "adagesnap.txt"), "w") as snapshot:
+        snapshot.write("engine state")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        input_files = workspace_manager._prepare_file_transfer().split(",")
+
+    assert input_files == [code_directory]
+    assert not any(
+        path == "_yadage" or path.startswith("_yadage/")
+        for path in workspace_manager.input_file_signatures
+    )
+
+
+def test_promote_output_ignores_returned_yadage_engine_state(workspace_manager):
+    """Do not overwrite Yadage state defensively if HTCondor returns it."""
+    workspace_manager.workflow.type_ = "yadage"
+    workspace = workspace_manager.workflow_workspace
+    yadage_state = os.path.join(workspace, "_yadage", "adage")
+    os.makedirs(yadage_state)
+    snapshot_path = os.path.join(yadage_state, "adagesnap.txt")
+    with open(snapshot_path, "w") as snapshot:
+        snapshot.write("current engine state")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    returned_yadage_state = os.path.join(
+        workspace_manager.file_transfer_workspace, "_yadage", "adage"
+    )
+    os.makedirs(returned_yadage_state)
+    with open(os.path.join(returned_yadage_state, "adagesnap.txt"), "w") as snapshot:
+        snapshot.write("stale engine state")
+    with open(
+        os.path.join(workspace_manager.file_transfer_workspace, "result.txt"), "w"
+    ) as result:
+        result.write("result")
+
+    workspace_manager.promote_output()
+
+    with open(snapshot_path) as snapshot:
+        assert snapshot.read() == "current engine state"
+    with open(os.path.join(workspace, "result.txt")) as result:
+        assert result.read() == "result"
+    assert not os.path.exists(workspace_manager.file_transfer_workspace)
+
+
+def test_promote_output_moves_only_new_and_modified_files(workspace_manager):
+    """Merge returned output without replacing unchanged input files."""
+    workspace = workspace_manager.workflow_workspace
+    input_path = os.path.join(workspace, "input.txt")
+    modified_path = os.path.join(workspace, "modified.txt")
+    with open(input_path, "w") as input_file:
+        input_file.write("unchanged")
+    input_inode = os.stat(input_path).st_ino
+    with open(modified_path, "w") as modified_file:
+        modified_file.write("before")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    transfer_workspace = workspace_manager.file_transfer_workspace
+    with open(os.path.join(transfer_workspace, "input.txt"), "w") as input_file:
+        input_file.write("unchanged")
+    with open(os.path.join(transfer_workspace, "modified.txt"), "w") as modified_file:
+        modified_file.write("after")
+    results = os.path.join(transfer_workspace, "results")
+    os.makedirs(results)
+    with open(os.path.join(results, "output.txt"), "w") as output_file:
+        output_file.write("result")
+    with open(os.path.join(transfer_workspace, "_condor_stdout"), "w") as stdout:
+        stdout.write("duplicate standard output")
+    with open(os.path.join(transfer_workspace, "_condor_stderr"), "w") as stderr:
+        stderr.write("duplicate standard error")
+    for filename in [
+        ".chirp.config",
+        ".job.ad",
+        ".machine.ad",
+        "condor_exec.exe",
+    ]:
+        with open(os.path.join(transfer_workspace, filename), "w") as internal_file:
+            internal_file.write("HTCondor internal file")
+    with open(os.path.join(transfer_workspace, "reana_job.123.0.out"), "w") as job_log:
+        job_log.write("canonical job output")
+
+    workspace_manager.promote_output()
+
+    with open(input_path) as input_file:
+        assert input_file.read() == "unchanged"
+    assert os.stat(input_path).st_ino == input_inode
+    with open(modified_path) as modified_file:
+        assert modified_file.read() == "after"
+    with open(os.path.join(workspace, "results", "output.txt")) as output_file:
+        assert output_file.read() == "result"
+    with open(os.path.join(workspace, "reana_job.123.0.out")) as job_log:
+        assert job_log.read() == "canonical job output"
+    assert not os.path.exists(os.path.join(workspace, "_condor_stdout"))
+    assert not os.path.exists(os.path.join(workspace, "_condor_stderr"))
+    for filename in workspace_manager.INTERNAL_OUTPUT_FILES:
+        assert not os.path.exists(os.path.join(workspace, filename))
+    assert not os.path.exists(transfer_workspace)
+
+
+def test_promote_output_detects_same_size_change_with_preserved_mtime(
+    workspace_manager,
+):
+    """Compare returned files lazily when transfer metadata is unchanged."""
+    workspace = workspace_manager.workflow_workspace
+    destination = os.path.join(workspace, "result.txt")
+    with open(destination, "w") as result_file:
+        result_file.write("before")
+    original_mtime = os.stat(destination).st_mtime_ns
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    returned_file = os.path.join(
+        workspace_manager.file_transfer_workspace, "result.txt"
+    )
+    with open(returned_file, "w") as result_file:
+        result_file.write("after!")
+    os.utime(returned_file, ns=(original_mtime, original_mtime))
+
+    workspace_manager.promote_output()
+
+    with open(destination) as result_file:
+        assert result_file.read() == "after!"
+
+
+def test_promote_output_preserves_input_symlink(workspace_manager):
+    """Do not replace an input symlink with HTCondor's dereferenced copy."""
+    workspace = workspace_manager.workflow_workspace
+    target = os.path.join(workspace, "target.txt")
+    input_link = os.path.join(workspace, "input-link")
+    with open(target, "w") as target_file:
+        target_file.write("input")
+    os.symlink("target.txt", input_link)
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    with open(
+        os.path.join(workspace_manager.file_transfer_workspace, "input-link"),
+        "w",
+    ) as returned_file:
+        returned_file.write("modified by job")
+
+    workspace_manager.promote_output()
+
+    assert os.path.islink(input_link)
+    assert os.readlink(input_link) == "target.txt"
+    with open(target) as target_file:
+        assert target_file.read() == "input"
+
+
+def test_promote_output_rejects_concurrent_modification(workspace_manager):
+    """Do not overwrite a workspace file changed while the job was running."""
+    workspace = workspace_manager.workflow_workspace
+    destination = os.path.join(workspace, "result.txt")
+    with open(destination, "w") as result_file:
+        result_file.write("before")
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    with open(destination, "w") as result_file:
+        result_file.write("local change")
+    with open(
+        os.path.join(workspace_manager.file_transfer_workspace, "result.txt"), "w"
+    ) as result_file:
+        result_file.write("remote change")
+
+    with pytest.raises(RuntimeError, match="concurrently modified"):
+        workspace_manager.promote_output()
+
+    with open(destination) as result_file:
+        assert result_file.read() == "local change"
+    assert os.path.isdir(workspace_manager.file_transfer_workspace)
+
+
+def test_promote_output_detects_replaced_file_with_preserved_metadata(
+    workspace_manager,
+):
+    """Use inode metadata to notice same-size local file replacement."""
+    workspace = workspace_manager.workflow_workspace
+    destination = os.path.join(workspace, "result.txt")
+    with open(destination, "w") as result_file:
+        result_file.write("before")
+    original_mtime = os.stat(destination).st_mtime_ns
+
+    with mock.patch.object(workspace_manager, "_copy_wrapper_file"):
+        workspace_manager._prepare_file_transfer()
+
+    replacement = os.path.join(workspace, "replacement.txt")
+    with open(replacement, "w") as result_file:
+        result_file.write("local!")
+    os.utime(replacement, ns=(original_mtime, original_mtime))
+    os.replace(replacement, destination)
+
+    returned_file = os.path.join(
+        workspace_manager.file_transfer_workspace, "result.txt"
+    )
+    with open(returned_file, "w") as result_file:
+        result_file.write("remote")
+    os.utime(returned_file, ns=(original_mtime, original_mtime))
+
+    with pytest.raises(RuntimeError, match="concurrently modified"):
+        workspace_manager.promote_output()
+
+    with open(destination) as result_file:
+        assert result_file.read() == "local!"
 
 
 # --- schedd interactions ------------------------------------------------------
@@ -333,6 +628,17 @@ def test_spool_input_passes_submit_result_to_schedd():
         Manager._spool_input(result)
 
     schedd.spool.assert_called_once_with(result)
+
+
+def test_stop_removes_job_and_its_spooled_files(manager):
+    """Removing an HTCondor job must also release its remote spool data."""
+    schedd = mock.MagicMock()
+    Manager = htcondorcern_job_manager.HTCondorJobManagerCERN
+
+    with mock.patch.object(Manager, "_get_schedd", return_value=schedd):
+        manager.stop(123)
+
+    schedd.act.assert_called_once_with(htcondor.JobAction.Remove, "ClusterId==123")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -45,6 +45,13 @@ def _build_user_secret(value, secret_type):
     }
 
 
+def test_job_manager_reserves_job_uuid_during_initialisation():
+    """Make the REANA job UUID available before backend submission."""
+    job_manager = JobManager()
+
+    assert str(uuid.UUID(job_manager.job_id)) == job_manager.job_id
+
+
 @pytest.mark.parametrize("kerberos", [False, True])
 def test_execute_kubernetes_job(
     app,

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,6 +38,217 @@ def test_initialisation(app):
         JobMonitorHTCondorCERN(app=app)
         JobMonitorKubernetes(app=app)
         JobMonitorSlurmCERN(app=app)
+
+
+@pytest.mark.parametrize("exit_code,expected_status", [(0, "finished"), (1, "failed")])
+def test_htcondor_finalises_job_after_promoting_output(exit_code, expected_status):
+    """Publish the final job status only after output has been retrieved."""
+    calls = mock.Mock()
+    app = mock.MagicMock()
+    manager = mock.MagicMock()
+    manager.workflow_workspace = "/workspace"
+    manager.promote_output.side_effect = calls.promote_output
+    job = {
+        "backend_job_id": 123,
+        "deleted": False,
+        "obj": manager,
+    }
+
+    def submit(function, *args, **kwargs):
+        future = mock.Mock()
+        if function == manager.spool_output:
+            future.result.side_effect = calls.retrieve_output
+        else:
+
+            def read_logs():
+                calls.read_logs()
+                return "job logs"
+
+            future.result.side_effect = read_logs
+        return future
+
+    app.htcondor_executor.submit.side_effect = submit
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch(
+            "reana_job_controller.job_monitor.store_job_logs",
+            side_effect=calls.store_logs,
+        ) as store_job_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status",
+            side_effect=calls.update_status,
+        ) as update_job_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = manager
+        monitor._finalise_completed_job(
+            "reana-job-id", job, {"ExitCode": exit_code}, app
+        )
+
+    assert calls.mock_calls == [
+        mock.call.retrieve_output(),
+        mock.call.promote_output(),
+        mock.call.read_logs(),
+        mock.call.store_logs("reana-job-id", "job logs"),
+        mock.call.update_status("reana-job-id", expected_status),
+    ]
+    store_job_logs.assert_called_once_with("reana-job-id", "job logs")
+    update_job_status.assert_called_once_with("reana-job-id", expected_status)
+    manager.stop.assert_not_called()
+    assert job["deleted"] is True
+
+
+def test_htcondor_fails_job_when_retrieving_output_fails():
+    """Do not report success when retrieving the HTCondor output fails."""
+    app = mock.MagicMock()
+    manager = mock.MagicMock()
+    manager.workflow_workspace = "/workspace"
+    job = {
+        "backend_job_id": 123,
+        "deleted": False,
+        "obj": manager,
+    }
+    future = mock.Mock()
+    future.result.side_effect = RuntimeError("sandbox transfer failed")
+    app.htcondor_executor.submit.return_value = future
+
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch("reana_job_controller.job_monitor.store_job_logs") as store_job_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status"
+        ) as update_job_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = manager
+        monitor._finalise_completed_job("reana-job-id", job, {"ExitCode": 0}, app)
+
+    stored_logs = store_job_logs.call_args.args[1]
+    assert "Failed to retrieve output" in stored_logs
+    assert "sandbox transfer failed" in stored_logs
+    update_job_status.assert_called_once_with("reana-job-id", "failed")
+    assert app.htcondor_executor.submit.call_count == 1
+    manager.stop.assert_called_once_with(123)
+    manager.cleanup_file_transfer.assert_called_once_with()
+    manager.promote_output.assert_not_called()
+    assert job["deleted"] is True
+
+
+def test_htcondor_fails_job_when_promoting_output_fails():
+    """Do not report success when promoting the retrieved output fails."""
+    app = mock.MagicMock()
+    manager = mock.MagicMock()
+    manager.workflow_workspace = "/workspace"
+    manager.promote_output.side_effect = RuntimeError("workspace conflict")
+    job = {"backend_job_id": 123, "deleted": False, "obj": manager}
+    future = mock.Mock()
+    future.result.return_value = None
+    app.htcondor_executor.submit.return_value = future
+
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch("reana_job_controller.job_monitor.store_job_logs") as store_job_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status"
+        ) as update_job_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = manager
+        monitor._finalise_completed_job("reana-job-id", job, {"ExitCode": 0}, app)
+
+    stored_logs = store_job_logs.call_args.args[1]
+    assert "Failed to promote output" in stored_logs
+    assert "workspace conflict" in stored_logs
+    update_job_status.assert_called_once_with("reana-job-id", "failed")
+    assert app.htcondor_executor.submit.call_count == 1
+    manager.stop.assert_not_called()
+    manager.cleanup_file_transfer.assert_called_once_with()
+    assert job["deleted"] is True
+
+
+def _watch_one_htcondor_iteration(monitor, job_db, app):
+    """Run one monitor iteration before interrupting its polling loop."""
+    with (
+        mock.patch(
+            "reana_job_controller.job_monitor.time.sleep",
+            side_effect=KeyboardInterrupt,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        monitor.watch_jobs(job_db, app)
+
+
+def test_htcondor_cleans_file_transfer_for_job_found_in_history():
+    """Clean local staging when a missing queue job is found in history."""
+    app = mock.MagicMock()
+    query_future = mock.Mock()
+    query_future.result.return_value = []
+    history_future = mock.Mock()
+    history_future.result.return_value = {"ClusterId": 123, "JobStatus": 4}
+    app.htcondor_executor.submit.side_effect = [query_future, history_future]
+    manager = mock.MagicMock()
+    job = {
+        "backend_job_id": 123,
+        "compute_backend": "htcondorcern",
+        "deleted": False,
+        "obj": manager,
+        "status": "running",
+    }
+    job_db = {"reana-job-id": job}
+
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch("reana_job_controller.job_monitor.store_job_logs") as store_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status"
+        ) as update_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = mock.MagicMock()
+        _watch_one_htcondor_iteration(monitor, job_db, app)
+
+    update_status.assert_called_once_with("reana-job-id", "failed")
+    store_logs.assert_called_once()
+    manager.cleanup_file_transfer.assert_called_once_with()
+    assert job["deleted"] is True
+
+
+def test_htcondor_cleans_file_transfer_for_held_job():
+    """Fail held jobs and clean their local staging directory."""
+    app = mock.MagicMock()
+    query_future = mock.Mock()
+    query_future.result.return_value = [
+        {"ClusterId": 123, "JobStatus": 5, "HoldReasonCode": 1}
+    ]
+    app.htcondor_executor.submit.return_value = query_future
+    manager = mock.MagicMock()
+    job = {
+        "backend_job_id": 123,
+        "compute_backend": "htcondorcern",
+        "deleted": False,
+        "obj": manager,
+        "status": "running",
+    }
+    job_db = {"reana-job-id": job}
+
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch("reana_job_controller.job_monitor.store_job_logs") as store_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status"
+        ) as update_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = mock.MagicMock()
+        _watch_one_htcondor_iteration(monitor, job_db, app)
+
+    monitor.job_manager_cls.stop.assert_called_once_with(123)
+    store_logs.assert_called_once_with(
+        "reana-job-id", "HTCondor job 123 was held with reason code 1."
+    )
+    update_status.assert_called_once_with("reana-job-id", "failed")
+    manager.cleanup_file_transfer.assert_called_once_with()
+    assert job["deleted"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -46,6 +46,7 @@ def test_htcondor_finalises_job_after_promoting_output(exit_code, expected_statu
     calls = mock.Mock()
     app = mock.MagicMock()
     manager = mock.MagicMock()
+    manager.file_transfer_workspace = "/workspace/.file-transfer"
     manager.workflow_workspace = "/workspace"
     manager.promote_output.side_effect = calls.promote_output
     job = {
@@ -87,13 +88,18 @@ def test_htcondor_finalises_job_after_promoting_output(exit_code, expected_statu
 
     assert calls.mock_calls == [
         mock.call.retrieve_output(),
-        mock.call.promote_output(),
         mock.call.read_logs(),
+        mock.call.promote_output(),
         mock.call.store_logs("reana-job-id", "job logs"),
         mock.call.update_status("reana-job-id", expected_status),
     ]
     store_job_logs.assert_called_once_with("reana-job-id", "job logs")
     update_job_status.assert_called_once_with("reana-job-id", expected_status)
+    assert app.htcondor_executor.submit.call_args_list[1] == mock.call(
+        manager.get_logs,
+        123,
+        workspace=manager.file_transfer_workspace,
+    )
     manager.stop.assert_not_called()
     assert job["deleted"] is True
 
@@ -138,12 +144,19 @@ def test_htcondor_fails_job_when_promoting_output_fails():
     """Do not report success when promoting the retrieved output fails."""
     app = mock.MagicMock()
     manager = mock.MagicMock()
+    manager.file_transfer_workspace = "/workspace/.file-transfer"
     manager.workflow_workspace = "/workspace"
     manager.promote_output.side_effect = RuntimeError("workspace conflict")
     job = {"backend_job_id": 123, "deleted": False, "obj": manager}
-    future = mock.Mock()
-    future.result.return_value = None
-    app.htcondor_executor.submit.return_value = future
+
+    def submit(function, *args, **kwargs):
+        future = mock.Mock()
+        future.result.return_value = (
+            None if function == manager.spool_output else "captured job logs"
+        )
+        return future
+
+    app.htcondor_executor.submit.side_effect = submit
 
     with (
         mock.patch("reana_job_controller.job_monitor.threading"),
@@ -157,12 +170,56 @@ def test_htcondor_fails_job_when_promoting_output_fails():
         monitor._finalise_completed_job("reana-job-id", job, {"ExitCode": 0}, app)
 
     stored_logs = store_job_logs.call_args.args[1]
+    assert stored_logs.startswith("captured job logs\n")
     assert "Failed to promote output" in stored_logs
     assert "workspace conflict" in stored_logs
     update_job_status.assert_called_once_with("reana-job-id", "failed")
-    assert app.htcondor_executor.submit.call_count == 1
+    assert app.htcondor_executor.submit.call_count == 2
+    assert app.htcondor_executor.submit.call_args_list[1] == mock.call(
+        manager.get_logs,
+        123,
+        workspace=manager.file_transfer_workspace,
+    )
     manager.stop.assert_not_called()
     manager.cleanup_file_transfer.assert_called_once_with()
+    assert job["deleted"] is True
+
+
+def test_htcondor_fails_job_when_capturing_output_logs_fails():
+    """Finalise the job even when reading the retrieved logs raises."""
+    app = mock.MagicMock()
+    manager = mock.MagicMock()
+    manager.file_transfer_workspace = "/workspace/.file-transfer"
+    job = {"backend_job_id": 123, "deleted": False, "obj": manager}
+
+    def submit(function, *args, **kwargs):
+        future = mock.Mock()
+        if function == manager.spool_output:
+            future.result.return_value = None
+        else:
+            future.result.side_effect = RuntimeError("cannot read sandbox logs")
+        return future
+
+    app.htcondor_executor.submit.side_effect = submit
+
+    with (
+        mock.patch("reana_job_controller.job_monitor.threading"),
+        mock.patch("reana_job_controller.job_monitor.store_job_logs") as store_job_logs,
+        mock.patch(
+            "reana_job_controller.job_monitor.update_job_status"
+        ) as update_job_status,
+    ):
+        monitor = JobMonitorHTCondorCERN(app=app)
+        monitor.job_manager_cls = manager
+        monitor._finalise_completed_job("reana-job-id", job, {"ExitCode": 0}, app)
+
+    stored_logs = store_job_logs.call_args.args[1]
+    assert "Failed to capture output logs" in stored_logs
+    assert "cannot read sandbox logs" in stored_logs
+    update_job_status.assert_called_once_with("reana-job-id", "failed")
+    assert app.htcondor_executor.submit.call_count == 2
+    manager.promote_output.assert_called_once_with()
+    manager.cleanup_file_transfer.assert_not_called()
     assert job["deleted"] is True
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -101,7 +101,7 @@ def test_htcondor_field_absence_is_allowed(field):
 
 def test_htcondor_requirements_accepts_valid_classad_expression():
     """A valid ClassAd expression passes the htcondor_requirements validator."""
-    pytest.importorskip("classad")
+    pytest.importorskip("classad2")
     payload = dict(
         BASE_JOB_REQUEST,
         htcondor_requirements='(Arch =?= "aarch64")',
@@ -112,7 +112,7 @@ def test_htcondor_requirements_accepts_valid_classad_expression():
 
 def test_htcondor_requirements_rejects_invalid_classad_expression():
     """An unparseable ClassAd expression is rejected with a clear message."""
-    pytest.importorskip("classad")
+    pytest.importorskip("classad2")
     payload = dict(
         BASE_JOB_REQUEST,
         htcondor_requirements="(Arch =?= ",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,6 +18,8 @@ from mock import Mock, patch
 from reana_commons.config import REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
 from reana_commons.job_utils import serialise_job_command
 
+from reana_job_controller.job_db import JOB_DB
+
 
 def test_delete_job(app, mocked_job):
     """Test valid job deletion."""
@@ -77,13 +79,78 @@ def test_delete_job_failed_backend(app, mocked_job):
             assert res.status_code == 502
 
 
+def test_delete_htcondor_job_cleans_file_transfer(app, monkeypatch):
+    """Clean local HTCondor staging after explicitly deleting a job."""
+    job_id = str(uuid.uuid4())
+    job_manager = Mock()
+    backend_manager = Mock()
+    monkeypatch.setitem(
+        JOB_DB,
+        job_id,
+        {
+            "backend_job_id": 123,
+            "obj": job_manager,
+        },
+    )
+    monkeypatch.setitem(
+        app.config["COMPUTE_BACKENDS"],
+        "htcondorcern",
+        lambda: backend_manager,
+    )
+
+    with app.test_client() as client:
+        response = client.delete(
+            url_for("jobs.delete_job", job_id=job_id),
+            query_string={"compute_backend": "htcondorcern"},
+        )
+
+    assert response.status_code == 204
+    backend_manager.stop.assert_called_once_with(123)
+    job_manager.cleanup_file_transfer.assert_called_once_with()
+
+
+def test_shutdown_cleans_htcondor_file_transfer(app):
+    """Clean local HTCondor staging when the controller shuts down."""
+    job_id = str(uuid.uuid4())
+    job_manager = Mock(workflow_workspace="/workspace")
+    backend_manager = Mock()
+    job = {
+        "backend_job_id": 123,
+        "compute_backend": "htcondorcern",
+        "obj": job_manager,
+    }
+    listed_jobs = [{job_id: {"status": "running"}}]
+
+    with (
+        patch.dict(JOB_DB, {job_id: job}, clear=True),
+        patch.dict(
+            "reana_job_controller.config.COMPUTE_BACKENDS",
+            {"htcondorcern": lambda: backend_manager},
+            clear=True,
+        ),
+        patch(
+            "reana_job_controller.rest.retrieve_all_jobs",
+            return_value=listed_jobs,
+        ),
+        patch("reana_job_controller.rest.store_job_logs"),
+        patch("reana_job_controller.rest.update_job_status"),
+        patch("reana_job_controller.rest.job_creation_condition.disable_creation"),
+        app.test_client() as client,
+    ):
+        response = client.get(url_for("jobs.shutdown"))
+
+    assert response.status_code == 200
+    backend_manager.stop.assert_called_once_with(123)
+    job_manager.cleanup_file_transfer.assert_called_once_with()
+
+
 @patch("reana_job_controller.schemas.REANA_KUBERNETES_JOBS_TIMEOUT_LIMIT", "10")
 @patch(
     "reana_job_controller.schemas.REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT", "20"
 )
 def test_create_job_unsupported_backend(app, job_spec):
     """Test create job with unsupported backend."""
-    fake_backend = "htcondorcern"
+    fake_backend = "unsupported"
     expected_msg = "Job submission failed. Backend {} is not supported.".format(
         fake_backend
     )


### PR DESCRIPTION
    Migrate the CERN HTCondor backend from the deprecated classad and
    htcondor modules to the supported classad2 and htcondor2 API.

    Preserve existing submission behaviour by expressing standard submit
    commands through htcondor2.Submit and retaining CERN-specific job
    attributes as MY.* entries. Keep caller-supplied Requirements as the
    complete matching expression.

    Adapt spooled submission, queue queries, and history handling to the
    return types and method names exposed by htcondor2.

    Require the HTCondor 24.12 LTS Python bindings so Linux amd64 and arm64
    images use the maintained API and matching ClassAd parser.

    Extend unit tests to cover submit descriptions, spooling, monitoring,
    history lookups, resource requests, and ClassAd validation.
    
   
Note that this branch depends on earlier Slurm improvement branch #528 due to macOS test harness fixes that that branch implements. (So that one should be reviewed and merged sooner, and this branch will be rebased afterwards.) 